### PR TITLE
API change, typo fixes.

### DIFF
--- a/client/bemenu-run.c
+++ b/client/bemenu-run.c
@@ -9,7 +9,7 @@
 #include "../lib/3rdparty/tinydir.h"
 
 static struct client client = {
-    .prioritory = BM_PRIO_ANY,
+    .priority = BM_PRIO_ANY,
     .filter_mode = BM_FILTER_MODE_DMENU,
     .wrap = 0,
     .lines = 0,

--- a/client/bemenu.c
+++ b/client/bemenu.c
@@ -5,7 +5,7 @@
 #include "common.h"
 
 static struct client client = {
-    .prioritory = BM_PRIO_ANY,
+    .priority = BM_PRIO_ANY,
     .filter_mode = BM_FILTER_MODE_DMENU,
     .wrap = 0,
     .lines = 0,

--- a/client/common/common.c
+++ b/client/common/common.c
@@ -70,7 +70,7 @@ usage(FILE *out, const char *name)
           " -P, --prefix          text to shown before highlighted item.\n"
           " -I, --index           select item at index automatically.\n"
           " --backend             options: curses, wayland, x11\n"
-          " --prioritory          options: terminal, gui\n\n"
+          " --priority          options: terminal, gui\n\n"
 
           "Backend specific options\n"
           "   c = ncurses, w == wayland, x == x11\n"
@@ -111,7 +111,7 @@ parse_args(struct client *client, int *argc, char **argv[])
         { "index",       required_argument, 0, 'I' },
         { "prefix",      required_argument, 0, 'P' },
         { "backend",     required_argument, 0, 0x100 },
-        { "prioritory",  required_argument, 0, 0x101 },
+        { "priority",  required_argument, 0, 0x101 },
 
         { "bottom",      no_argument,       0, 'b' },
         { "grab",        no_argument,       0, 'f' },
@@ -175,9 +175,9 @@ parse_args(struct client *client, int *argc, char **argv[])
 
             case 0x101:
                 if (!strcmp(optarg, "terminal"))
-                    client->prioritory = BM_PRIO_TERMINAL;
+                    client->priority = BM_PRIO_TERMINAL;
                 else if (!strcmp(optarg, "gui"))
-                    client->prioritory = BM_PRIO_GUI;
+                    client->priority = BM_PRIO_GUI;
                 break;
 
             case 'b':
@@ -247,7 +247,7 @@ struct bm_menu*
 menu_with_options(struct client *client)
 {
     struct bm_menu *menu;
-    if (!(menu = bm_menu_new(client->renderer, client->prioritory)))
+    if (!(menu = bm_menu_new(client->renderer, client->priority)))
         return NULL;
 
     bm_menu_set_font(menu, client->font);

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -4,7 +4,7 @@
 #include <bemenu.h>
 
 struct client {
-    enum bm_prioritory prioritory;
+    enum bm_priority priority;
     enum bm_filter_mode filter_mode;
     int32_t wrap;
     uint32_t lines;

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -85,7 +85,7 @@ const char* bm_version(void);
 /**
  * Prioritories for renderer plugins.
  */
-enum bm_prioritory {
+enum bm_priority {
     /**
      * Do not use this in renderers.
      * This flag is for bm_menu_new, if any renderer is fine.
@@ -112,12 +112,12 @@ enum bm_prioritory {
 const char* bm_renderer_get_name(const struct bm_renderer *renderer);
 
 /**
- * Get prioritory of the renderer.
+ * Get priority of the renderer.
  *
  * @param renderer bm_renderer instance.
- * @return bm_prioritory enum value.
+ * @return bm_priority enum value.
  */
-enum bm_prioritory bm_renderer_get_prioritory(const struct bm_renderer *renderer);
+enum bm_priority bm_renderer_get_priority(const struct bm_renderer *renderer);
 
 /**
  * @} Renderer */
@@ -211,10 +211,10 @@ enum bm_color {
  * Create new bm_menu instance.
  *
  * @param renderer Name of renderer to be used for this instance, pass **NULL** for auto-detection.
- * @param prioritory @link ::bm_prioritory @endlink enum for which kind of renderer is wanted. Pass BM_PRIO_ANY, for anything.
+ * @param priority @link ::bm_priority @endlink enum for which kind of renderer is wanted. Pass BM_PRIO_ANY, for anything.
  * @return bm_menu for new menu instance, **NULL** if creation failed.
  */
-struct bm_menu* bm_menu_new(const char *renderer, enum bm_prioritory prioritory);
+struct bm_menu* bm_menu_new(const char *renderer, enum bm_priority priority);
 
 /**
  * Release bm_menu instance.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -93,10 +93,10 @@ struct render_api {
     const char *version;
 
     /**
-     * Prioritory of the plugin.
+     * priority of the plugin.
      * Terminal renderers should be first, then graphicals.
      */
-    enum bm_prioritory prioritory;
+    enum bm_priority priority;
 };
 
 /**

--- a/lib/library.c
+++ b/lib/library.c
@@ -67,7 +67,7 @@ static int
 compare(const void *a, const void *b)
 {
     const struct bm_renderer *ra = *(struct bm_renderer**)a, *rb = *(struct bm_renderer**)b;
-    return (ra->api.prioritory > rb->api.prioritory);
+    return (ra->api.priority > rb->api.priority);
 }
 
 static bool
@@ -180,11 +180,11 @@ bm_renderer_get_name(const struct bm_renderer *renderer)
     return renderer->name;
 }
 
-enum bm_prioritory
-bm_renderer_get_prioritory(const struct bm_renderer *renderer)
+enum bm_priority
+bm_renderer_get_priority(const struct bm_renderer *renderer)
 {
     assert(renderer);
-    return renderer->api.prioritory;
+    return renderer->api.priority;
 }
 
 /* vim: set ts=8 sw=4 tw=0 :*/

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -49,7 +49,7 @@ bm_menu_item_is_selected(const struct bm_menu *menu, const struct bm_item *item)
 }
 
 struct bm_menu*
-bm_menu_new(const char *renderer, enum bm_prioritory prioritory)
+bm_menu_new(const char *renderer, enum bm_priority priority)
 {
     struct bm_menu *menu;
     if (!(menu = calloc(1, sizeof(struct bm_menu))))
@@ -59,13 +59,13 @@ bm_menu_new(const char *renderer, enum bm_prioritory prioritory)
     const struct bm_renderer **renderers = bm_get_renderers(&count);
 
     for (uint32_t i = 0; i < count; ++i) {
-        if (prioritory != BM_PRIO_ANY && renderers[i]->api.prioritory != prioritory)
+        if (priority != BM_PRIO_ANY && renderers[i]->api.priority != priority)
             continue;
 
         if (renderer && strcmp(renderer, renderers[i]->name))
             continue;
 
-        if (renderers[i]->api.prioritory == BM_PRIO_TERMINAL) {
+        if (renderers[i]->api.priority == BM_PRIO_TERMINAL) {
             const char *term = getenv("TERM");
             if (!term || !strlen(term) || getppid() == 1)
                 continue;

--- a/lib/renderers/curses/curses.c
+++ b/lib/renderers/curses/curses.c
@@ -361,7 +361,7 @@ register_renderer(struct render_api *api)
     api->get_displayed_count = get_displayed_count;
     api->poll_key = poll_key;
     api->render = render;
-    api->prioritory = BM_PRIO_TERMINAL;
+    api->priority = BM_PRIO_TERMINAL;
     api->version = BM_PLUGIN_VERSION;
     return "curses";
 }

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -235,7 +235,7 @@ register_renderer(struct render_api *api)
     api->get_displayed_count = get_displayed_count;
     api->poll_key = poll_key;
     api->render = render;
-    api->prioritory = BM_PRIO_GUI;
+    api->priority = BM_PRIO_GUI;
     api->version = BM_PLUGIN_VERSION;
     return "wayland";
 }

--- a/lib/renderers/x11/x11.c
+++ b/lib/renderers/x11/x11.c
@@ -227,7 +227,7 @@ register_renderer(struct render_api *api)
     api->set_bottom = set_bottom;
     api->set_monitor = set_monitor;
     api->grab_keyboard = grab_keyboard;
-    api->prioritory = BM_PRIO_GUI;
+    api->priority = BM_PRIO_GUI;
     api->version = BM_PLUGIN_VERSION;
     return "x11";
 }


### PR DESCRIPTION
This just fixes the spelling of priority before it gets baked into the API and becomes unchangeable.