### PR TITLE
Make protocol specifications follow the DTD

### DIFF
--- a/lib/renderers/wayland/xdg-shell.xml
+++ b/lib/renderers/wayland/xdg-shell.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<protocol name="xdg_shell">
+<protocol name="xdg_shell_unstable_v5">
 
   <copyright>
     Copyright © 2008-2013 Kristian Høgsberg
@@ -7,94 +7,108 @@
     Copyright © 2013      Jasper St. Pierre
     Copyright © 2010-2013 Intel Corporation
 
-    Permission to use, copy, modify, distribute, and sell this
-    software and its documentation for any purpose is hereby granted
-    without fee, provided that the above copyright notice appear in
-    all copies and that both that copyright notice and this permission
-    notice appear in supporting documentation, and that the name of
-    the copyright holders not be used in advertising or publicity
-    pertaining to distribution of the software without specific,
-    written prior permission.  The copyright holders make no
-    representations about the suitability of this software for any
-    purpose.  It is provided "as is" without express or implied
-    warranty.
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
 
-    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
-    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
-    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
-    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
-    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
-    THIS SOFTWARE.
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
   </copyright>
 
   <interface name="xdg_shell" version="1">
     <description summary="create desktop-style surfaces">
-      This interface is implemented by servers that provide
-      desktop-style user interfaces.
-
-      It allows clients to associate a xdg_surface with
-      a basic surface.
+      xdg_shell allows clients to turn a wl_surface into a "real window"
+      which can be dragged, resized, stacked, and moved around by the
+      user. Everything about this interface is suited towards traditional
+      desktop environments.
     </description>
 
     <enum name="version">
       <description summary="latest protocol version">
-	The 'current' member of this enum gives the version of the
-	protocol.  Implementations can compare this to the version
-	they implement using static_assert to ensure the protocol and
-	implementation versions match.
+    The 'current' member of this enum gives the version of the
+    protocol.  Implementations can compare this to the version
+    they implement using static_assert to ensure the protocol and
+    implementation versions match.
       </description>
-      <entry name="current" value="4" summary="Always the latest version"/>
+      <entry name="current" value="5" summary="Always the latest version"/>
     </enum>
 
     <enum name="error">
       <entry name="role" value="0" summary="given wl_surface has another role"/>
+      <entry name="defunct_surfaces" value="1" summary="xdg_shell was destroyed before children"/>
+      <entry name="not_the_topmost_popup" value="2" summary="the client tried to map or destroy a non-topmost popup"/>
+      <entry name="invalid_popup_parent" value="3" summary="the client specified an invalid popup parent surface"/>
     </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy xdg_shell">
+        Destroy this xdg_shell object.
+
+        Destroying a bound xdg_shell object while there are surfaces
+        still alive created by this xdg_shell object instance is illegal
+        and will result in a protocol error.
+      </description>
+    </request>
 
     <request name="use_unstable_version">
       <description summary="enable use of this unstable version">
-	Negotiate the unstable version of the interface.  This
-	mechanism is in place to ensure client and server agree on the
-	unstable versions of the protocol that they speak or exit
-	cleanly if they don't agree.  This request will go away once
-	the xdg-shell protocol is stable.
+    Negotiate the unstable version of the interface.  This
+    mechanism is in place to ensure client and server agree on the
+    unstable versions of the protocol that they speak or exit
+    cleanly if they don't agree.  This request will go away once
+    the xdg-shell protocol is stable.
       </description>
       <arg name="version" type="int"/>
     </request>
 
     <request name="get_xdg_surface">
       <description summary="create a shell surface from a surface">
-	Create a shell surface for an existing surface.
+    This creates an xdg_surface for the given surface and gives it the
+    xdg_surface role. A wl_surface can only be given an xdg_surface role
+    once. If get_xdg_surface is called with a wl_surface that already has
+    an active xdg_surface associated with it, or if it had any other role,
+    an error is raised.
 
-	This request gives the surface the role of xdg_surface. If the
-	surface already has another role, it raises a protocol error.
-
-	Only one shell or popup surface can be associated with a given
-	surface.
+    See the documentation of xdg_surface for more details about what an
+    xdg_surface is and how it is used.
       </description>
       <arg name="id" type="new_id" interface="xdg_surface"/>
       <arg name="surface" type="object" interface="wl_surface"/>
     </request>
 
     <request name="get_xdg_popup">
-      <description summary="create a shell surface from a surface">
-	Create a popup surface for an existing surface.
+      <description summary="create a popup for a surface">
+    This creates an xdg_popup for the given surface and gives it the
+    xdg_popup role. A wl_surface can only be given an xdg_popup role
+    once. If get_xdg_popup is called with a wl_surface that already has
+    an active xdg_popup associated with it, or if it had any other role,
+    an error is raised.
 
-	This request gives the surface the role of xdg_popup. If the
-	surface already has another role, it raises a protocol error.
+    This request must be used in response to some sort of user action
+    like a button press, key press, or touch down event.
 
-	Only one shell or popup surface can be associated with a given
-	surface.
+    See the documentation of xdg_popup for more details about what an
+    xdg_popup is and how it is used.
       </description>
       <arg name="id" type="new_id" interface="xdg_popup"/>
       <arg name="surface" type="object" interface="wl_surface"/>
       <arg name="parent" type="object" interface="wl_surface"/>
-      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat whose pointer is used"/>
-      <arg name="serial" type="uint" summary="serial of the implicit grab on the pointer"/>
+      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
       <arg name="x" type="int"/>
       <arg name="y" type="int"/>
-      <arg name="flags" type="uint"/>
     </request>
 
     <event name="ping">
@@ -107,22 +121,24 @@
         alive. It's unspecified what will happen if the client doesn't
         respond to the ping request, or in what timeframe. Clients should
         try to respond in a reasonable amount of time.
+
+        A compositor is free to ping in any way it wants, but a client must
+        always respond to any xdg_shell object it created.
       </description>
-      <arg name="serial" type="uint" summary="pass this to the callback"/>
+      <arg name="serial" type="uint" summary="pass this to the pong request"/>
     </event>
 
     <request name="pong">
       <description summary="respond to a ping event">
-	A client must respond to a ping event with a pong request or
-	the client may be deemed unresponsive.
+    A client must respond to a ping event with a pong request or
+    the client may be deemed unresponsive.
       </description>
       <arg name="serial" type="uint" summary="serial of the ping event"/>
     </request>
   </interface>
 
   <interface name="xdg_surface" version="1">
-
-    <description summary="desktop-style metadata interface">
+    <description summary="A desktop window">
       An interface that may be implemented by a wl_surface, for
       implementations that provide a desktop-style user interface.
 
@@ -130,53 +146,76 @@
       properties like maximized, fullscreen, minimized, and to move and resize
       them, and associate metadata like title and app id.
 
-      On the server side the object is automatically destroyed when
-      the related wl_surface is destroyed.  On client side,
-      xdg_surface.destroy() must be called before destroying
-      the wl_surface object.
+      The client must call wl_surface.commit on the corresponding wl_surface
+      for the xdg_surface state to take effect. Prior to committing the new
+      state, it can set up initial configuration, such as maximizing or setting
+      a window geometry.
+
+      Even without attaching a buffer the compositor must respond to initial
+      committed configuration, for instance sending a configure event with
+      expected window geometry if the client maximized its surface during
+      initialization.
+
+      For a surface to be mapped by the compositor the client must have
+      committed both an xdg_surface state and a buffer.
     </description>
 
     <request name="destroy" type="destructor">
-      <description summary="remove xdg_surface interface">
-	The xdg_surface interface is removed from the wl_surface object
-	that was turned into a xdg_surface with
-	xdg_shell.get_xdg_surface request. The xdg_surface properties,
-	like maximized and fullscreen, are lost. The wl_surface loses
-	its role as a xdg_surface. The wl_surface is unmapped.
+      <description summary="Destroy the xdg_surface">
+    Unmap and destroy the window. The window will be effectively
+    hidden from the user's point of view, and all state like
+    maximization, fullscreen, and so on, will be lost.
       </description>
     </request>
 
     <request name="set_parent">
-      <description summary="surface is a child of another surface">
-	Child surfaces are stacked above their parents, and will be
-	unmapped if the parent is unmapped too. They should not appear
-	on task bars and alt+tab.
+      <description summary="set the parent of this surface">
+    Set the "parent" of this surface. This window should be stacked
+    above a parent. The parent surface must be mapped as long as this
+    surface is mapped.
+
+    Parent windows should be set on dialogs, toolboxes, or other
+    "auxiliary" surfaces, so that the parent is raised when the dialog
+    is raised.
       </description>
-      <arg name="parent" type="object" interface="wl_surface" allow-null="true"/>
+      <arg name="parent" type="object" interface="xdg_surface" allow-null="true"/>
     </request>
 
     <request name="set_title">
       <description summary="set surface title">
-	Set a short title for the surface.
+    Set a short title for the surface.
 
-	This string may be used to identify the surface in a task bar,
-	window list, or other user interface elements provided by the
-	compositor.
+    This string may be used to identify the surface in a task bar,
+    window list, or other user interface elements provided by the
+    compositor.
 
-	The string must be encoded in UTF-8.
+    The string must be encoded in UTF-8.
       </description>
       <arg name="title" type="string"/>
     </request>
 
     <request name="set_app_id">
-      <description summary="set surface class">
-	Set an id for the surface.
+      <description summary="set application ID">
+    Set an application identifier for the surface.
 
-	The app id identifies the general class of applications to which
-	the surface belongs.
+    The app ID identifies the general class of applications to which
+    the surface belongs. The compositor can use this to group multiple
+    surfaces together, or to determine how to launch a new application.
 
-	It should be the ID that appears in the new desktop entry
-	specification, the interface name.
+    For D-Bus activatable applications, the app ID is used as the D-Bus
+    service name.
+
+    The compositor shell will try to group application surfaces together
+    by their app ID.  As a best practice, it is suggested to select app
+    ID's that match the basename of the application's .desktop file.
+    For example, "org.freedesktop.FooViewer" where the .desktop file is
+    "org.freedesktop.FooViewer.desktop".
+
+    See the desktop-entry specification [0] for more details on
+    application identifiers and how they relate to well-known D-Bus
+    names and .desktop files.
+
+    [0] http://standards.freedesktop.org/desktop-entry-spec/
       </description>
       <arg name="app_id" type="string"/>
     </request>
@@ -188,37 +227,47 @@
         user a menu that they can use to maximize or minimize the window.
 
         This request asks the compositor to pop up such a window menu at
-        the given position, relative to the parent surface. There are
-        no guarantees as to what the window menu contains.
+        the given position, relative to the local surface coordinates of
+        the parent surface. There are no guarantees as to what menu items
+        the window menu contains.
 
-        Your surface must have focus on the seat passed in to pop up the
-        window menu.
+        This request must be used in response to some sort of user action
+        like a button press, key press, or touch down event.
       </description>
 
-      <arg name="seat" type="object" interface="wl_seat" summary="the seat to pop the window up on"/>
-      <arg name="serial" type="uint" summary="serial of the event to pop up the window for"/>
+      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
       <arg name="x" type="int" summary="the x position to pop up the window menu at"/>
       <arg name="y" type="int" summary="the y position to pop up the window menu at"/>
     </request>
 
     <request name="move">
       <description summary="start an interactive move">
-	Start a pointer-driven move of the surface.
+    Start an interactive, user-driven move of the surface.
 
-	This request must be used in response to a button press event.
-	The server may ignore move requests depending on the state of
-	the surface (e.g. fullscreen or maximized).
+    This request must be used in response to some sort of user action
+    like a button press, key press, or touch down event. The passed
+    serial is used to determine the type of interactive move (touch,
+    pointer, etc).
+
+    The server may ignore move requests depending on the state of
+    the surface (e.g. fullscreen or maximized), or if the passed serial
+    is no longer valid.
+
+    If triggered, the surface will lose the focus of the device
+    (wl_pointer, wl_touch, etc) used for the move. It is up to the
+    compositor to visually indicate that the move is taking place, such as
+    updating a pointer cursor, during the move. There is no guarantee
+    that the device focus will return when the move is completed.
       </description>
-      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat whose pointer is used"/>
-      <arg name="serial" type="uint" summary="serial of the implicit grab on the pointer"/>
+      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
     </request>
 
     <enum name="resize_edge">
       <description summary="edge values for resizing">
-	These values are used to indicate which edge of a surface
-	is being dragged in a resize operation. The server may
-	use this information to adapt its behavior, e.g. choose
-	an appropriate cursor image.
+    These values are used to indicate which edge of a surface
+    is being dragged in a resize operation.
       </description>
       <entry name="none" value="0"/>
       <entry name="top" value="1"/>
@@ -233,14 +282,39 @@
 
     <request name="resize">
       <description summary="start an interactive resize">
-	Start a pointer-driven resizing of the surface.
+    Start a user-driven, interactive resize of the surface.
 
-	This request must be used in response to a button press event.
-	The server may ignore resize requests depending on the state of
-	the surface (e.g. fullscreen or maximized).
+    This request must be used in response to some sort of user action
+    like a button press, key press, or touch down event. The passed
+    serial is used to determine the type of interactive resize (touch,
+    pointer, etc).
+
+    The server may ignore resize requests depending on the state of
+    the surface (e.g. fullscreen or maximized).
+
+    If triggered, the client will receive configure events with the
+    "resize" state enum value and the expected sizes. See the "resize"
+    enum value for more details about what is required. The client
+    must also acknowledge configure events using "ack_configure". After
+    the resize is completed, the client will receive another "configure"
+    event without the resize state.
+
+    If triggered, the surface also will lose the focus of the device
+    (wl_pointer, wl_touch, etc) used for the resize. It is up to the
+    compositor to visually indicate that the resize is taking place,
+    such as updating a pointer cursor, during the resize. There is no
+    guarantee that the device focus will return when the resize is
+    completed.
+
+    The edges parameter specifies how the surface should be resized,
+    and is one of the values of the resize_edge enum. The compositor
+    may use this information to update the surface position for
+    example when dragging the top left corner. The compositor may also
+    use this information to adapt its behavior, e.g. choose an
+    appropriate cursor image.
       </description>
-      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat whose pointer is used"/>
-      <arg name="serial" type="uint" summary="serial of the implicit grab on the pointer"/>
+      <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
+      <arg name="serial" type="uint" summary="the serial of the user event"/>
       <arg name="edges" type="uint" summary="which edge or corner is being dragged"/>
     </request>
 
@@ -264,42 +338,61 @@
 
         0x0000 - 0x0FFF: xdg-shell core values, documented below.
         0x1000 - 0x1FFF: GNOME
+        0x2000 - 0x2FFF: EFL
       </description>
       <entry name="maximized" value="1" summary="the surface is maximized">
-        The surface is maximized. The window geometry specified in the configure
-        event must be obeyed by the client.
+    <description summary="the surface is maximized">
+      The surface is maximized. The window geometry specified in the configure
+      event must be obeyed by the client.
+    </description>
       </entry>
       <entry name="fullscreen" value="2" summary="the surface is fullscreen">
-        The surface is fullscreen. The window geometry specified in the configure
-        event must be obeyed by the client.
+    <description summary="the surface is fullscreen">
+      The surface is fullscreen. The window geometry specified in the configure
+      event must be obeyed by the client.
+    </description>
       </entry>
-      <entry name="resizing" value="3">
-        The surface is being resized. The window geometry specified in the
-        configure event is a maximum; the client cannot resize beyond it.
-        Clients that have aspect ratio or cell sizing configuration can use
-        a smaller size, however.
+      <entry name="resizing" value="3" summary="the surface is being resized">
+    <description summary="the surface is being resized">
+      The surface is being resized. The window geometry specified in the
+      configure event is a maximum; the client cannot resize beyond it.
+      Clients that have aspect ratio or cell sizing configuration can use
+      a smaller size, however.
+    </description>
       </entry>
-      <entry name="activated" value="4">
-        Client window decorations should be painted as if the window is
-        active. Do not assume this means that the window actually has
-        keyboard or pointer focus.
+      <entry name="activated" value="4" summary="the surface is now activated">
+    <description summary="the surface is now activated">
+      Client window decorations should be painted as if the window is
+      active. Do not assume this means that the window actually has
+      keyboard or pointer focus.
+    </description>
       </entry>
     </enum>
 
     <event name="configure">
       <description summary="suggest a surface change">
-	The configure event asks the client to resize its surface.
+    The configure event asks the client to resize its surface or to
+    change its state.
 
-	The width and height arguments specify a hint to the window
-        about how its surface should be resized in window geometry
-        coordinates. The states listed in the event specify how the
-        width/height arguments should be interpreted.
+    The width and height arguments specify a hint to the window
+    about how its surface should be resized in window geometry
+    coordinates. See set_window_geometry.
 
-        A client should arrange a new surface, and then send a
-        ack_configure request with the serial sent in this configure
-        event before attaching a new surface.
+    If the width or height arguments are zero, it means the client
+    should decide its own window dimension. This may happen when the
+    compositor need to configure the state of the surface but doesn't
+    have any information about any previous or expected dimension.
 
-	If the client receives multiple configure events before it
+    The states listed in the event specify how the width/height
+    arguments should be interpreted, and possibly how it should be
+    drawn.
+
+    Clients should arrange their surface for the new size and
+    states, and then send a ack_configure request with the serial
+    sent in this configure event at some point before committing
+    the new surface.
+
+    If the client receives multiple configure events before it
         can respond to one, it is free to discard all but the last
         event it received.
       </description>
@@ -312,14 +405,27 @@
 
     <request name="ack_configure">
       <description summary="ack a configure event">
-        When a configure event is received, a client should then ack it
-        using the ack_configure request to ensure that the compositor
-        knows the client has seen the event.
+        When a configure event is received, if a client commits the
+        surface in response to the configure event, then the client
+        must make an ack_configure request sometime before the commit
+        request, passing along the serial of the configure event.
 
-        By this point, the state is confirmed, and the next attach should
-        contain the buffer drawn for the configure event you are acking.
+        For instance, the compositor might use this information to move
+        a surface to the top left only when the client has drawn itself
+        for the maximized or fullscreen state.
+
+        If the client receives multiple configure events before it
+        can respond to one, it only has to ack the last configure event.
+
+        A client is not required to commit immediately after sending
+        an ack_configure request - it may even ack_configure several times
+        before its next surface commit.
+
+        The compositor expects that the most recently received
+        ack_configure request at the time of a commit indicates which
+        configure event the client is responding to.
       </description>
-      <arg name="serial" type="uint" summary="a serial to configure for"/>
+      <arg name="serial" type="uint" summary="the serial from the configure event"/>
     </request>
 
     <request name="set_window_geometry">
@@ -329,15 +435,26 @@
         portions like drop-shadows which should be ignored for the
         purposes of aligning, placing and constraining windows.
 
-        The default value is the full bounds of the surface, including any
-        subsurfaces. Once the window geometry of the surface is set once,
-        it is not possible to unset it, and it will remain the same until
+        The window geometry is double buffered, and will be applied at the
+        time wl_surface.commit of the corresponding wl_surface is called.
+
+        Once the window geometry of the surface is set once, it is not
+        possible to unset it, and it will remain the same until
         set_window_geometry is called again, even if a new subsurface or
         buffer is attached.
+
+        If never set, the value is the full bounds of the surface,
+        including any subsurfaces. This updates dynamically on every
+        commit. This unset mode is meant for extremely simple clients.
 
         If responding to a configure event, the window geometry in here
         must respect the sizing negotiations specified by the states in
         the configure event.
+
+        The arguments are given in the surface local coordinate space of
+        the wl_surface associated with this xdg_surface.
+
+        The width and height must be greater than zero.
       </description>
       <arg name="x" type="int"/>
       <arg name="y" type="int"/>
@@ -345,22 +462,77 @@
       <arg name="height" type="int"/>
     </request>
 
-    <request name="set_maximized" />
-    <request name="unset_maximized" />
+    <request name="set_maximized">
+      <description summary="maximize the window">
+        Maximize the surface.
+
+        After requesting that the surface should be maximized, the compositor
+        will respond by emitting a configure event with the "maximized" state
+        and the required window geometry. The client should then update its
+        content, drawing it in a maximized state, i.e. without shadow or other
+        decoration outside of the window geometry. The client must also
+        acknowledge the configure when committing the new content (see
+        ack_configure).
+
+        It is up to the compositor to decide how and where to maximize the
+        surface, for example which output and what region of the screen should
+        be used.
+
+        If the surface was already maximized, the compositor will still emit
+        a configure event with the "maximized" state.
+      </description>
+    </request>
+
+    <request name="unset_maximized">
+      <description summary="unmaximize the window">
+        Unmaximize the surface.
+
+        After requesting that the surface should be unmaximized, the compositor
+        will respond by emitting a configure event without the "maximized"
+        state. If available, the compositor will include the window geometry
+        dimensions the window had prior to being maximized in the configure
+        request. The client must then update its content, drawing it in a
+        regular state, i.e. potentially with shadow, etc. The client must also
+        acknowledge the configure when committing the new content (see
+        ack_configure).
+
+        It is up to the compositor to position the surface after it was
+        unmaximized; usually the position the surface had before maximizing, if
+        applicable.
+
+        If the surface was already not maximized, the compositor will still
+        emit a configure event without the "maximized" state.
+      </description>
+    </request>
 
     <request name="set_fullscreen">
       <description summary="set the window as fullscreen on a monitor">
-	Make the surface fullscreen.
+    Make the surface fullscreen.
 
         You can specify an output that you would prefer to be fullscreen.
-	If this value is NULL, it's up to the compositor to choose which
+    If this value is NULL, it's up to the compositor to choose which
         display will be used to map this surface.
+
+        If the surface doesn't cover the whole output, the compositor will
+        position the surface in the center of the output and compensate with
+        black borders filling the rest of the output.
       </description>
       <arg name="output" type="object" interface="wl_output" allow-null="true"/>
     </request>
     <request name="unset_fullscreen" />
 
-    <request name="set_minimized" />
+    <request name="set_minimized">
+      <description summary="set the window as minimized">
+    Request that the compositor minimize your surface. There is no
+    way to know if the surface is currently minimized, nor is there
+    any way to unset minimization on this surface.
+
+    If you are looking to throttle redrawing when minimized, please
+    instead use the wl_surface.frame event for this, as this will
+    also work with live previews on windows in Alt-Tab, Expose or
+    similar compositor features.
+      </description>
+    </request>
 
     <event name="close">
       <description summary="surface wants to be closed">
@@ -377,45 +549,76 @@
   </interface>
 
   <interface name="xdg_popup" version="1">
-    <description summary="desktop-style metadata interface">
-      An interface that may be implemented by a wl_surface, for
-      implementations that provide a desktop-style popups/menus. A popup
-      surface is a transient surface with an added pointer grab.
+    <description summary="short-lived, popup surfaces for menus">
+      A popup surface is a short-lived, temporary surface that can be
+      used to implement menus. It takes an explicit grab on the surface
+      that will be dismissed when the user dismisses the popup. This can
+      be done by the user clicking outside the surface, using the keyboard,
+      or even locking the screen through closing the lid or a timeout.
 
-      An existing implicit grab will be changed to owner-events mode,
-      and the popup grab will continue after the implicit grab ends
-      (i.e. releasing the mouse button does not cause the popup to be
-      unmapped).
+      When the popup is dismissed, a popup_done event will be sent out,
+      and at the same time the surface will be unmapped. The xdg_popup
+      object is now inert and cannot be reactivated, so clients should
+      destroy it. Explicitly destroying the xdg_popup object will also
+      dismiss the popup and unmap the surface.
 
-      The popup grab continues until the window is destroyed or a mouse
-      button is pressed in any other clients window. A click in any of
-      the clients surfaces is reported as normal, however, clicks in
-      other clients surfaces will be discarded and trigger the callback.
+      Clients will receive events for all their surfaces during this
+      grab (which is an "owner-events" grab in X11 parlance). This is
+      done so that users can navigate through submenus and other
+      "nested" popup windows without having to dismiss the topmost
+      popup.
 
-      The x and y arguments specify the locations of the upper left
-      corner of the surface relative to the upper left corner of the
-      parent surface, in surface local coordinates.
+      Clients that want to dismiss the popup when another surface of
+      their own is clicked should dismiss the popup using the destroy
+      request.
 
-      xdg_popup surfaces are always transient for another surface.
+      The parent surface must have either an xdg_surface or xdg_popup
+      role.
+
+      Specifying an xdg_popup for the parent means that the popups are
+      nested, with this popup now being the topmost popup. Nested
+      popups must be destroyed in the reverse order they were created
+      in, e.g. the only popup you are allowed to destroy at all times
+      is the topmost one.
+
+      If there is an existing popup when creating a new popup, the
+      parent must be the current topmost popup.
+
+      A parent surface must be mapped before the new popup is mapped.
+
+      When compositors choose to dismiss a popup, they will likely
+      dismiss every nested popup as well. When a compositor dismisses
+      popups, it will follow the same dismissing order as required
+      from the client.
+
+      The x and y arguments passed when creating the popup object specify
+      where the top left of the popup should be placed, relative to the
+      local surface coordinates of the parent surface. See
+      xdg_shell.get_xdg_popup.
+
+      The client must call wl_surface.commit on the corresponding wl_surface
+      for the xdg_popup state to take effect.
+
+      For a surface to be mapped by the compositor the client must have
+      committed both the xdg_popup state and a buffer.
     </description>
 
     <request name="destroy" type="destructor">
-      <description summary="remove xdg_surface interface">
-	The xdg_surface interface is removed from the wl_surface object
-	that was turned into a xdg_surface with
-	xdg_shell.get_xdg_surface request. The xdg_surface properties,
-	like maximized and fullscreen, are lost. The wl_surface loses
-	its role as a xdg_surface. The wl_surface is unmapped.
+      <description summary="remove xdg_popup interface">
+    This destroys the popup. Explicitly destroying the xdg_popup
+    object will also dismiss the popup, and unmap the surface.
+
+    If this xdg_popup is not the "topmost" popup, a protocol error
+    will be sent.
       </description>
     </request>
 
     <event name="popup_done">
       <description summary="popup interaction is done">
-	The popup_done event is sent out when a popup grab is broken,
-	that is, when the users clicks a surface that doesn't belong
-	to the client owning the popup surface.
+    The popup_done event is sent out when a popup is dismissed by the
+    compositor. The client should destroy the xdg_popup object at this
+    point.
       </description>
-      <arg name="serial" type="uint" summary="serial of the implicit grab on the pointer"/>
     </event>
 
   </interface>


### PR DESCRIPTION
Gets rid of these warnings when building:

    WARNING: XML failed validation against built-in DTD