### PR TITLE
Remove double slash from os anonymous file

### DIFF
--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -50,7 +50,7 @@ create_tmpfile_cloexec(char *tmpname)
 static int
 os_create_anonymous_file(off_t size)
 {
-    static const char template[] = "/bemenu-shared-XXXXXX";
+    static const char template[] = "bemenu-shared-XXXXXX";
     int fd;
     int ret;
 


### PR DESCRIPTION
the anonymous file path is created from
- the XDG_RUNTIME path (with optional slash at the end)
- a slash if the XDG_RUNTIME path didn't have one
- and the tmpfile template (which starts with a slash).
This guarantees there are always two slashes before the filename.
It does not affect the behaviour of the program, but I've removed it anyway.