### PR TITLE
Add C-m -> Return bind

### DIFF
--- a/lib/renderers/curses/curses.c
+++ b/lib/renderers/curses/curses.c
@@ -327,6 +327,7 @@ poll_key(const struct bm_menu *menu, uint32_t *unicode)
             return BM_KEY_SHIFT_RETURN;
 
         case 10: /* Return */
+        case 13: /* C-m */
             terminate();
             return BM_KEY_RETURN;
 

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -151,6 +151,9 @@ poll_key(const struct bm_menu *menu, unsigned int *unicode)
         case XKB_KEY_d:
             return (mods & MOD_ALT ? BM_KEY_PAGE_DOWN : BM_KEY_UNICODE);
 
+        case XKB_KEY_m:
+            return (mods & MOD_CTRL ? BM_KEY_RETURN : BM_KEY_UNICODE);
+
         default: break;
     }
 

--- a/lib/renderers/x11/x11.c
+++ b/lib/renderers/x11/x11.c
@@ -140,6 +140,9 @@ poll_key(const struct bm_menu *menu, unsigned int *unicode)
         case XK_d:
             return (mods & MOD_ALT ? BM_KEY_PAGE_DOWN : BM_KEY_UNICODE);
 
+        case XK_m:
+            return (mods & MOD_CTRL ? BM_KEY_RETURN : BM_KEY_UNICODE);
+
         default: break;
     }
 


### PR DESCRIPTION
C-m is often bound to return and it's jarring to have all the
other keybinds but not this one