### PR TITLE
Wayland renderer: implement bottom option

### DIFF
--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -178,6 +178,18 @@ get_displayed_count(const struct bm_menu *menu)
 }
 
 static void
+set_bottom(const struct bm_menu *menu, bool bottom)
+{
+    struct wayland *wayland = menu->renderer->internal;
+    assert(wayland);
+
+    struct window *window;
+    wl_list_for_each(window, &wayland->windows, link) {
+        bm_wl_window_set_bottom(window, wayland->display, bottom);
+    }
+}
+
+static void
 destructor(struct bm_menu *menu)
 {
     struct wayland *wayland = menu->renderer->internal;
@@ -234,6 +246,7 @@ constructor(struct bm_menu *menu)
 	if (!(surface = wl_compositor_create_surface(wayland->compositor)))
 	    goto fail;
 	struct window *window = calloc(1, sizeof(struct window));
+	window->bottom = menu->bottom;
 	if (!bm_wl_window_create(window, wayland->display, wayland->shm, output->output, wayland->layer_shell, surface))
 	    goto fail;
 	window->notify.render = bm_cairo_paint;
@@ -268,6 +281,7 @@ register_renderer(struct render_api *api)
     api->get_displayed_count = get_displayed_count;
     api->poll_key = poll_key;
     api->render = render;
+    api->set_bottom = set_bottom;
     api->priorty = BM_PRIO_GUI;
     api->version = BM_PLUGIN_VERSION;
     return "wayland";

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -242,16 +242,16 @@ constructor(struct bm_menu *menu)
 
     struct output *output;
     wl_list_for_each(output, &wayland->outputs, link) {
-	struct wl_surface *surface;
-	if (!(surface = wl_compositor_create_surface(wayland->compositor)))
-	    goto fail;
-	struct window *window = calloc(1, sizeof(struct window));
-	window->bottom = menu->bottom;
-	if (!bm_wl_window_create(window, wayland->display, wayland->shm, output->output, wayland->layer_shell, surface))
-	    goto fail;
-	window->notify.render = bm_cairo_paint;
-	window->max_height = output->height;
-	wl_list_insert(&wayland->windows, &window->link);
+        struct wl_surface *surface;
+        if (!(surface = wl_compositor_create_surface(wayland->compositor)))
+            goto fail;
+        struct window *window = calloc(1, sizeof(struct window));
+        window->bottom = menu->bottom;
+        if (!bm_wl_window_create(window, wayland->display, wayland->shm, output->output, wayland->layer_shell, surface))
+            goto fail;
+        window->notify.render = bm_cairo_paint;
+        window->max_height = output->height;
+        wl_list_insert(&wayland->windows, &window->link);
     }
 
     if (!efd && (efd = epoll_create(EPOLL_CLOEXEC)) < 0)

--- a/lib/renderers/wayland/wayland.h
+++ b/lib/renderers/wayland/wayland.h
@@ -83,6 +83,7 @@ struct window {
     uint32_t width, height, max_height;
     uint32_t displayed;
     struct wl_list link;
+    bool bottom;
 
     struct {
         void (*render)(struct cairo *cairo, uint32_t width, uint32_t height, uint32_t max_height, const struct bm_menu *menu, struct cairo_paint_result *result);
@@ -117,6 +118,7 @@ void bm_wl_repeat(struct wayland *wayland);
 bool bm_wl_registry_register(struct wayland *wayland);
 void bm_wl_registry_destroy(struct wayland *wayland);
 void bm_wl_window_render(struct window *window, const struct bm_menu *menu);
+void bm_wl_window_set_bottom(struct window *window, struct wl_display *display, bool bottom);
 bool bm_wl_window_create(struct window *window, struct wl_display *display, struct wl_shm *shm, struct wl_output *output, struct zwlr_layer_shell_v1 *layer_shell, struct wl_surface *surface);
 void bm_wl_window_destroy(struct window *window);
 

--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -279,6 +279,19 @@ static const struct zwlr_layer_surface_v1_listener layer_surface_listener = {
     .closed = layer_surface_closed,
 };
 
+void
+bm_wl_window_set_bottom(struct window *window, struct wl_display *display, bool bottom)
+{
+    if (window->bottom == bottom)
+        return;
+
+    window->bottom = bottom;
+
+    zwlr_layer_surface_v1_set_anchor(window->layer_surface, (window->bottom ? ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM : ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP) | ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT | ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
+    wl_surface_commit(window->surface);
+    wl_display_roundtrip(display);
+}
+
 bool
 bm_wl_window_create(struct window *window, struct wl_display *display, struct wl_shm *shm, struct wl_output *output, struct zwlr_layer_shell_v1 *layer_shell, struct wl_surface *surface)
 {
@@ -286,7 +299,7 @@ bm_wl_window_create(struct window *window, struct wl_display *display, struct wl
 
     if (layer_shell && (window->layer_surface = zwlr_layer_shell_v1_get_layer_surface(layer_shell, surface, output, ZWLR_LAYER_SHELL_V1_LAYER_TOP, "menu"))) {
         zwlr_layer_surface_v1_add_listener(window->layer_surface, &layer_surface_listener, window);
-        zwlr_layer_surface_v1_set_anchor(window->layer_surface, ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT | ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
+        zwlr_layer_surface_v1_set_anchor(window->layer_surface, (window->bottom ? ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM : ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP) | ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT | ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
         zwlr_layer_surface_v1_set_size(window->layer_surface, 0, 32);
         zwlr_layer_surface_v1_set_keyboard_interactivity(window->layer_surface, true);
         wl_surface_commit(surface);


### PR DESCRIPTION
I tried to mimic what x11 does; this isn't super efficient because `menu->bottom` isn't actually set when we create the windows but I guess it works anyway (might flicker a bit? I can't see it if so)

That `wlr_layer_surface_v1_set_anchor` line is getting super long too, happy to do whatever you think is good with it.