### PR TITLE
More wayland fixes

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -82,7 +82,7 @@ usage(FILE *out, const char *name)
           "   c = ncurses, w == wayland, x == x11\n"
           "   (...) At end of help indicates the backend support for option.\n\n"
 
-          " -b, --bottom          appears at the bottom of the screen. (x)\n"
+          " -b, --bottom          appears at the bottom of the screen. (wx)\n"
           " -f, --grab            show the menu before reading stdin. (wx)\n"
           " -m, --monitor         index of monitor where menu will appear. (x)\n"
           " --fn                  defines the font to be used ('name [size]'). (wx)\n"

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -40,7 +40,7 @@ render(const struct bm_menu *menu)
     if (wayland->input.code != wayland->input.last_code) {
         struct window *window;
             wl_list_for_each(window, &wayland->windows, link) {
-            bm_wl_window_render(window, menu);
+            bm_wl_window_render(window, wayland->display, menu);
         }
         wayland->input.last_code = wayland->input.code;
     }

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -190,6 +190,18 @@ set_bottom(const struct bm_menu *menu, bool bottom)
 }
 
 static void
+grab_keyboard(const struct bm_menu *menu, bool grab)
+{
+    struct wayland *wayland = menu->renderer->internal;
+    assert(wayland);
+
+    struct window *window;
+    wl_list_for_each(window, &wayland->windows, link) {
+        bm_wl_window_grab_keyboard(window, wayland->display, grab);
+    }
+}
+
+static void
 destructor(struct bm_menu *menu)
 {
     struct wayland *wayland = menu->renderer->internal;
@@ -282,6 +294,7 @@ register_renderer(struct render_api *api)
     api->poll_key = poll_key;
     api->render = render;
     api->set_bottom = set_bottom;
+    api->grab_keyboard = grab_keyboard;
     api->priorty = BM_PRIO_GUI;
     api->version = BM_PLUGIN_VERSION;
     return "wayland";

--- a/lib/renderers/wayland/wayland.h
+++ b/lib/renderers/wayland/wayland.h
@@ -119,6 +119,7 @@ bool bm_wl_registry_register(struct wayland *wayland);
 void bm_wl_registry_destroy(struct wayland *wayland);
 void bm_wl_window_render(struct window *window, struct wl_display *display, const struct bm_menu *menu);
 void bm_wl_window_set_bottom(struct window *window, struct wl_display *display, bool bottom);
+void bm_wl_window_grab_keyboard(struct window *window, struct wl_display *display, bool grab);
 bool bm_wl_window_create(struct window *window, struct wl_display *display, struct wl_shm *shm, struct wl_output *output, struct zwlr_layer_shell_v1 *layer_shell, struct wl_surface *surface);
 void bm_wl_window_destroy(struct window *window);
 

--- a/lib/renderers/wayland/wayland.h
+++ b/lib/renderers/wayland/wayland.h
@@ -117,7 +117,7 @@ struct wayland {
 void bm_wl_repeat(struct wayland *wayland);
 bool bm_wl_registry_register(struct wayland *wayland);
 void bm_wl_registry_destroy(struct wayland *wayland);
-void bm_wl_window_render(struct window *window, const struct bm_menu *menu);
+void bm_wl_window_render(struct window *window, struct wl_display *display, const struct bm_menu *menu);
 void bm_wl_window_set_bottom(struct window *window, struct wl_display *display, bool bottom);
 bool bm_wl_window_create(struct window *window, struct wl_display *display, struct wl_shm *shm, struct wl_output *output, struct zwlr_layer_shell_v1 *layer_shell, struct wl_surface *surface);
 void bm_wl_window_destroy(struct window *window);

--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -321,7 +321,6 @@ bm_wl_window_create(struct window *window, struct wl_display *display, struct wl
 
     window->shm = shm;
     window->surface = surface;
-    wl_surface_damage(surface, 0, 0, window->width, window->height);
     return true;
 }
 

--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -204,7 +204,7 @@ static const struct wl_callback_listener listener = {
 };
 
 void
-bm_wl_window_render(struct window *window, const struct bm_menu *menu)
+bm_wl_window_render(struct window *window, struct wl_display *display, const struct bm_menu *menu)
 {
     assert(window && menu);
 
@@ -229,6 +229,9 @@ bm_wl_window_render(struct window *window, const struct bm_menu *menu)
             break;
 
         window->height = result.height;
+        zwlr_layer_surface_v1_set_size(window->layer_surface, 0, window->height);
+        wl_surface_commit(window->surface);
+        wl_display_roundtrip(display);
         destroy_buffer(buffer);
     }
 
@@ -299,6 +302,7 @@ bm_wl_window_create(struct window *window, struct wl_display *display, struct wl
 
     if (layer_shell && (window->layer_surface = zwlr_layer_shell_v1_get_layer_surface(layer_shell, surface, output, ZWLR_LAYER_SHELL_V1_LAYER_TOP, "menu"))) {
         zwlr_layer_surface_v1_add_listener(window->layer_surface, &layer_surface_listener, window);
+        zwlr_layer_surface_v1_set_exclusive_zone(window->layer_surface, -1);
         zwlr_layer_surface_v1_set_anchor(window->layer_surface, (window->bottom ? ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM : ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP) | ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT | ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
         zwlr_layer_surface_v1_set_size(window->layer_surface, 0, 32);
         zwlr_layer_surface_v1_set_keyboard_interactivity(window->layer_surface, true);

--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -295,6 +295,14 @@ bm_wl_window_set_bottom(struct window *window, struct wl_display *display, bool 
     wl_display_roundtrip(display);
 }
 
+void
+bm_wl_window_grab_keyboard(struct window *window, struct wl_display *display, bool grab)
+{
+    zwlr_layer_surface_v1_set_keyboard_interactivity(window->layer_surface, grab);
+    wl_surface_commit(window->surface);
+    wl_display_roundtrip(display);
+}
+
 bool
 bm_wl_window_create(struct window *window, struct wl_display *display, struct wl_shm *shm, struct wl_output *output, struct zwlr_layer_shell_v1 *layer_shell, struct wl_surface *surface)
 {
@@ -305,7 +313,6 @@ bm_wl_window_create(struct window *window, struct wl_display *display, struct wl
         zwlr_layer_surface_v1_set_exclusive_zone(window->layer_surface, -1);
         zwlr_layer_surface_v1_set_anchor(window->layer_surface, (window->bottom ? ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM : ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP) | ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT | ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
         zwlr_layer_surface_v1_set_size(window->layer_surface, 0, 32);
-        zwlr_layer_surface_v1_set_keyboard_interactivity(window->layer_surface, true);
         wl_surface_commit(surface);
         wl_display_roundtrip(display);
     } else {


### PR DESCRIPTION
- I had positioning a bit wrong with my previous bottom PR; I thought it was just positioned above the bar by the compositor but it was just rendering to the top of a hard-coded 32 pixels buffer and leaving the bottom blank.
The first commit fixes that by setting size when it changes and requests to not honor exclude zone so we always have the X11 behavior of being at the very bottom.
We technically should call `wl_surface_commit` after `set_size` but it will be committed alongside the buffer right afterwards so I think that's fine? @SirCmpwn might know better.

- grab_keyboard is needed when running bemenu interactively, we previously grabbed keyboard on window creation before input was taken and there is no easy way out of this grab...

- last commit is a nitpick, but might as well remove what's not needed.

Happy to split in two PR if you think it's worth it, or whatever.