### PR TITLE
Fix blocking on Wayland

### DIFF
--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -26,7 +26,7 @@ render(const struct bm_menu *menu)
     }
 
     struct epoll_event ep[16];
-    uint32_t num = epoll_wait(efd, ep, 16, -1);
+    uint32_t num = epoll_wait(efd, ep, 16, 0);
     for (uint32_t i = 0; i < num; ++i) {
         if (ep[i].data.ptr == &wayland->fds.display) {
             if (ep[i].events & EPOLLERR || ep[i].events & EPOLLHUP ||


### PR DESCRIPTION
Sometimes bemenu blocks in epoll_wait which prevents bemenu from showing
up until another key is pressed or the mouse is moved. This may be
working around a compositor specific bug in Sway/Wlroots.

Backtrace from gdb attached to a running bemenu process that failed to render because it was stuck in epoll_wait:

```c
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
0x00007f2f8a6156ab in epoll_wait (epfd=5, events=events@entry=0x7ffdf6422d20, maxevents=maxevents@entry=16, timeout=timeout@entry=-1) at ../sysdeps/unix/sysv/linux/epoll_wait.c:30
30	../sysdeps/unix/sysv/linux/epoll_wait.c: No such file or directory.

Thread 1 (Thread 0x7f2f8a505740 (LWP 13002)):
#0  0x00007f2f8a6156ab in epoll_wait (epfd=5, events=events@entry=0x7ffdf6422d20, maxevents=maxevents@entry=16, timeout=timeout@entry=-1) at ../sysdeps/unix/sysv/linux/epoll_wait.c:30
        resultvar = 18446744073709551612
        sc_ret = <optimized out>
#1  0x00007f2f8a73adc9 in render (menu=0x55f797907110) at /usr/src/debug/dev-libs/bemenu-9999/bemenu-9999/lib/renderers/wayland/wayland.c:29
        wayland = 0x55f7978ef9a0
        ep = {{events = 0, data = {ptr = 0xf6422d6800000000, fd = 0, u32 = 0, u64 = 17744795406493024256}}, {events = 32765, data = {ptr = 0x55f7978efa80, fd = -1752237440, u32 = 2542729856, u64 = 94521888012928}}, {events = 2542729856, data = {ptr = 0x978efb60000055f7, fd = 22007, u32 = 22007, u64 = 10920942536155485687}}, {events = 22007, data = {ptr = 0x55f7978efb48, fd = -1752237240, u32 = 2542730056, u64 = 94521888013128}}, {events = 4294967295, data = {ptr = 0x8a72d34000000000, fd = 0, u32 = 0, u64 = 9976268396410437632}}, {events = 32559, data = {ptr = 0x3000000002, fd = 2, u32 = 2, u64 = 206158430210}}, {events = 3, data = {ptr = 0x978efb4800010001, fd = 65537, u32 = 65537, u64 = 10920942433076314113}}, {events = 22007, data = {ptr = 0x55f797955650, fd = -1751820720, u32 = 2543146576, u64 = 94521888429648}}, {events = 2542729856, data = {ptr = 0x978efb48000055f7, fd = 22007, u32 = 22007, u64 = 10920942433076270583}}, {events = 22007, data = {ptr = 0x55f797955540, fd = -1751820992, u32 = 2543146304, u64 = 94521888429376}}, {events = 2322780235, data = {ptr = 0x7f2f, fd = 32559, u32 = 32559, u64 = 32559}}, {events = 1, data = {ptr = 0x55f797911100, fd = -1752100608, u32 = 2542866688, u64 = 94521888149760}}, {events = 1, data = {ptr = 0x9628ca0500000000, fd = 0, u32 = 0, u64 = 10820120227581263872}}, {events = 22007, data = {ptr = 0x0, fd = 0, u32 = 0, u64 = 0}}, {events = 0, data = {ptr = 0x978efa8000000000, fd = 0, u32 = 0, u64 = 10920941574082789376}}, {events = 22007, data = {ptr = 0x7f2f8a73d78a <bm_wl_window_grab_keyboard+60>, fd = -1972119670, u32 = 2322847626, u64 = 139842163038090}}}
        num = <optimized out>
#2  0x00007f2f8a6e04ea in bm_menu_render (menu=menu@entry=0x55f797907110) at /usr/src/debug/dev-libs/bemenu-9999/bemenu-9999/lib/menu.c:522
No locals.
#3  0x000055f79628d2eb in run_menu (client=<optimized out>, menu=0x55f797907110, item_cb=0x55f79628ca05 <item_cb>) at /usr/src/debug/dev-libs/bemenu-9999/bemenu-9999/client/common/common.c:295
        unicode = 110
        key = <optimized out>
        status = <optimized out>
#4  0x000055f79628cb76 in main (argc=<optimized out>, argv=<optimized out>) at /usr/src/debug/dev-libs/bemenu-9999/bemenu-9999/client/bemenu.c:70
        menu = 0x55f797907110
        status = <optimized out>
A debugging session is active.

	Inferior 1 [process 13002] will be detached.

Quit anyway? (y or n) [answered Y; input not from terminal]
[Inferior 1 (process 13002) detached]
```