### PR TITLE
Prevent a deadloop in PATH handling

### DIFF
--- a/client/bemenu-run.c
+++ b/client/bemenu-run.c
@@ -66,6 +66,8 @@ get_paths(const char *env, const char *default_paths, struct paths *state)
         if ((f = strcspn(state->path, ":")) > 0) {
             state->path += f + (path[f] ? 1 : 0);
             path[f] = 0;
+        } else {
+            state->path += 1;
         }
 
         if (!*path) {


### PR DESCRIPTION
Empty PATH segments should no longer cause
a deadloop.

Fixes #59