### PR TITLE
Add C-g shortcut to x11 and wayland

### DIFF
--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -122,6 +122,8 @@ poll_key(const struct bm_menu *menu, unsigned int *unicode)
         case XKB_KEY_Return:
             return (mods & MOD_CTRL ? BM_KEY_CONTROL_RETURN : (mods & MOD_SHIFT ? BM_KEY_SHIFT_RETURN : BM_KEY_RETURN));
 
+        case XKB_KEY_g:
+            if (!(mods & MOD_CTRL)) return BM_KEY_UNICODE;
         case XKB_KEY_Escape:
             return BM_KEY_ESCAPE;
 

--- a/lib/renderers/x11/x11.c
+++ b/lib/renderers/x11/x11.c
@@ -101,6 +101,8 @@ poll_key(const struct bm_menu *menu, unsigned int *unicode)
         case XK_Return:
             return (mods & MOD_CTRL ? BM_KEY_CONTROL_RETURN : (mods & MOD_SHIFT ? BM_KEY_SHIFT_RETURN : BM_KEY_RETURN));
 
+        case XK_g:
+            if (!(mods & MOD_CTRL)) return BM_KEY_UNICODE;
         case XK_Escape:
             return BM_KEY_ESCAPE;
 


### PR DESCRIPTION
Very simple case to add the C-g shortcut I normally use to kill dmenu.