### PR TITLE
Add Ctrl-[ shortcut to x11 and wayland

### DIFF
--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -124,6 +124,8 @@ poll_key(const struct bm_menu *menu, unsigned int *unicode)
 
         case XKB_KEY_g:
             if (!(mods & MOD_CTRL)) return BM_KEY_UNICODE;
+        case XKB_KEY_bracketleft:
+            if (!(mods & MOD_CTRL)) return BM_KEY_UNICODE;
         case XKB_KEY_Escape:
             return BM_KEY_ESCAPE;
 

--- a/lib/renderers/x11/x11.c
+++ b/lib/renderers/x11/x11.c
@@ -103,6 +103,8 @@ poll_key(const struct bm_menu *menu, unsigned int *unicode)
 
         case XK_g:
             if (!(mods & MOD_CTRL)) return BM_KEY_UNICODE;
+        case XK_bracketleft:
+            if (!(mods & MOD_CTRL)) return BM_KEY_UNICODE;
         case XK_Escape:
             return BM_KEY_ESCAPE;
 


### PR DESCRIPTION
Ctrl-[ shortcut is used to quit bemenu. It already works with ncurses backend