### PR TITLE
Mark global wayland constant extern

### DIFF
--- a/lib/renderers/wayland/wayland.h
+++ b/lib/renderers/wayland/wayland.h
@@ -33,8 +33,8 @@ enum mask {
     MASK_LAST
 };
 
-const char *BM_XKB_MASK_NAMES[MASK_LAST];
-const enum mod_bit BM_XKB_MODS[MASK_LAST];
+extern const char *BM_XKB_MASK_NAMES[MASK_LAST];
+extern const enum mod_bit BM_XKB_MODS[MASK_LAST];
 
 struct xkb {
     struct xkb_state *state;


### PR DESCRIPTION
Without `extern`, the changed lines are not declarations, but "tentative definitions" (according to GCC man page, option `-fcommon`). When specified in a header file that is included in more than one `.c` file, these result in linking failure unless `-fcommon` is specified.

GCC 10 changed the default from `-fcommon` to `-fno-common`, and as such the previous code no longer links properly.

With `extern`, these lines are considered declarations, and the linking proceeds successfully.
