### PR TITLE
Add bemenu_path script

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,6 +19,7 @@ override CPPFLAGS += -D_DEFAULT_SOURCE -Ilib
 libs = libbemenu.so
 pkgconfigs = bemenu.pc
 bins = bemenu bemenu-run
+scripts = bemenu_path
 renderers = bemenu-renderer-x11.so bemenu-renderer-curses.so bemenu-renderer-wayland.so
 all: $(bins) $(renderers)
 clients: $(bins)
@@ -97,8 +98,9 @@ install-renderers:
 
 install-bins:
 	mkdir -p "$(DESTDIR)$(PREFIX)$(bindir)"
-	-cp $(bins) "$(DESTDIR)$(PREFIX)$(bindir)"
+	-cp $(bins) $(scripts) "$(DESTDIR)$(PREFIX)$(bindir)"
 	-chmod 0755 $(addprefix "$(DESTDIR)$(PREFIX)$(bindir)"/,$(bins))
+	-chmod 0755 $(addprefix "$(DESTDIR)$(PREFIX)$(bindir)"/,$(scripts))
 
 install-man: man/bemenu.1 man/bemenu-run.1
 	mkdir -p "$(DESTDIR)$(PREFIX)$(mandir)"

--- a/bemenu_path
+++ b/bemenu_path
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+cachedir="${XDG_CACHE_HOME:-"$HOME/.cache"}"
+cache="$cachedir/bemenu_path"
+
+[ ! -e "$cachedir" ] && mkdir -p "$cachedir"
+
+IFS=:
+if stest -dqr -n "$cache" $PATH; then
+	stest -flx $PATH | sort -u | tee "$cache"
+else
+	cat "$cache"
+fi


### PR DESCRIPTION
dmenu is generally packaged with a simple shell script, `dmenu_path` that generates a list of all files within a user's `$PATH`. This PR adds an equivalent script, `bemenu_path`, that does the same. This allows for use cases that use bemenu to select a program from the path, but not execute it.