### PR TITLE
Add --no-exec option to bemenu-run

### DIFF
--- a/client/bemenu-run.c
+++ b/client/bemenu-run.c
@@ -154,7 +154,12 @@ launch(const struct client *client, const char *bin)
 static void
 item_cb(const struct client *client, struct bm_item *item)
 {
-    launch(client, bm_item_get_text(item));
+    if (client->no_exec) {
+        const char *text = bm_item_get_text(item);
+        printf("%s\n", (text ? text : ""));
+    } else {
+        launch(client, bm_item_get_text(item));
+    }
 }
 
 int

--- a/client/common/common.c
+++ b/client/common/common.c
@@ -175,7 +175,8 @@ usage(FILE *out, const char *name)
           " -I, --index           select item at index automatically.\n"
           " --scrollbar           display scrollbar. (always, autohide)\n"
           " --ifne                only display menu if there are items.\n"
-          " --fork                always fork. (bemenu-run)\n\n"
+          " --fork                always fork. (bemenu-run)\n"
+          " --no-exec             do not execute command. (bemenu-run)\n\n"
 
           "Use BEMENU_BACKEND env variable to force backend:\n"
           " curses               ncurses based terminal backend\n"
@@ -228,6 +229,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
         { "scrollbar",   required_argument, 0, 0x100 },
         { "ifne",        no_argument,       0, 0x115 },
         { "fork",        no_argument,       0, 0x116 },
+        { "no-exec",     no_argument,       0, 0x117 },
 
         { "bottom",      no_argument,       0, 'b' },
         { "grab",        no_argument,       0, 'f' },
@@ -295,6 +297,9 @@ do_getopt(struct client *client, int *argc, char **argv[])
                 break;
             case 0x116:
                 client->force_fork = true;
+                break;
+            case 0x117:
+                client->no_exec = true;
                 break;
 
             case 'b':

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -21,6 +21,7 @@ struct client {
     bool ifne;
     bool no_overlap;
     bool force_fork, fork;
+    bool no_exec;
 };
 
 char* cstrcopy(const char *str, size_t size);

--- a/man/bemenu.1
+++ b/man/bemenu.1
@@ -96,6 +96,11 @@ Only displays the menu when there are items.
 Always fork. (bemenu-run)
 By default terminal backends won't fork.
 
+.TP
+.B \-\-no\-exec
+Do not execute command. (bemenu-run)
+Instead of running the selected item, send to stdout.
+
 .SS Backend-specific Options
 
 These options are only available on backends specified in the parentheses


### PR DESCRIPTION
As an alternative to the `dmenu_path` script, this PR adds a `--no-exec` option to `bemenu-run`. Setting this option will cause `bemenu-run` to print the selected command name to stdout rather than execute it.