### PR TITLE
Add transparency support

### DIFF
--- a/lib/internal.h
+++ b/lib/internal.h
@@ -169,7 +169,7 @@ struct bm_hex_color {
     /**
      * RGB values.
      */
-    uint8_t r, g, b;
+    uint8_t r, g, b, a;
 };
 
 /**

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -15,18 +15,18 @@ static const char *default_font = "monospace 10";
  * Default hexadecimal colors.
  */
 static const char *default_colors[BM_COLOR_LAST] = {
-    "#121212", // BM_COLOR_TITLE_BG
-    "#D81860", // BM_COLOR_TITLE_FG
-    "#121212", // BM_COLOR_FILTER_BG
-    "#CACACA", // BM_COLOR_FILTER_FG
-    "#121212", // BM_COLOR_ITEM_BG
-    "#CACACA", // BM_COLOR_ITEM_FG
-    "#121212", // BM_COLOR_HIGHLIGHTED_BG
-    "#D81860", // BM_COLOR_HIGHLIGHTED_FG
-    "#121212", // BM_COLOR_SELECTED_BG
-    "#D81860", // BM_COLOR_SELECTED_FG
-    "#121212", // BM_COLOR_SCROLLBAR_BG
-    "#D81860", // BM_COLOR_SCROLLBAR_FG
+    "#121212FF", // BM_COLOR_TITLE_BG
+    "#D81860FF", // BM_COLOR_TITLE_FG
+    "#121212FF", // BM_COLOR_FILTER_BG
+    "#CACACAFF", // BM_COLOR_FILTER_FG
+    "#121212FF", // BM_COLOR_ITEM_BG
+    "#CACACAFF", // BM_COLOR_ITEM_FG
+    "#121212FF", // BM_COLOR_HIGHLIGHTED_BG
+    "#D81860FF", // BM_COLOR_HIGHLIGHTED_FG
+    "#121212FF", // BM_COLOR_SELECTED_BG
+    "#D81860FF", // BM_COLOR_SELECTED_FG
+    "#121212FF", // BM_COLOR_SCROLLBAR_BG
+    "#D81860FF", // BM_COLOR_SCROLLBAR_FG
 };
 
 /**
@@ -301,8 +301,9 @@ bm_menu_set_color(struct bm_menu *menu, enum bm_color color, const char *hex)
 
     const char *nhex = (hex ? hex : default_colors[color]);
 
-    unsigned int r, g, b;
-    if (sscanf(nhex,"#%2x%2x%2x", &r, &b, &g) != 3)
+    unsigned int r, g, b, a = 255;
+    int matched = sscanf(nhex, "#%2x%2x%2x%2x", &r, &b, &g, &a);
+    if (matched != 3 && matched != 4)
         return false;
 
     char *copy = NULL;
@@ -314,6 +315,7 @@ bm_menu_set_color(struct bm_menu *menu, enum bm_color color, const char *hex)
     menu->colors[color].r = r;
     menu->colors[color].g = g;
     menu->colors[color].b = b;
+    menu->colors[color].a = a;
     return true;
 }
 

--- a/lib/renderers/cairo.h
+++ b/lib/renderers/cairo.h
@@ -200,7 +200,7 @@ bm_cairo_color_from_menu_color(const struct bm_menu *menu, enum bm_color color, 
     c->r = (float)menu->colors[color].r / 255.0f;
     c->g = (float)menu->colors[color].g / 255.0f;
     c->b = (float)menu->colors[color].b / 255.0f;
-    c->a = 1.0f;
+    c->a = (float)menu->colors[color].a / 255.0f;
 }
 
 static inline void
@@ -213,7 +213,7 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
     memset(out_result, 0, sizeof(struct cairo_paint_result));
     out_result->displayed = 1;
 
-    cairo_set_source_rgb(cairo->cr, 0, 0, 0);
+    cairo_set_source_rgba(cairo->cr, 0, 0, 0, 0);
     cairo_rectangle(cairo->cr, 0, 0, width, height);
     cairo_fill(cairo->cr);
 

--- a/lib/renderers/cairo.h
+++ b/lib/renderers/cairo.h
@@ -214,7 +214,7 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
     out_result->displayed = 1;
 
     cairo_set_source_rgba(cairo->cr, 0, 0, 0, 0);
-    cairo_rectangle(cairo->cr, 0, 0, width, height);
+    cairo_set_operator(cairo->cr, CAIRO_OPERATOR_SOURCE);
     cairo_fill(cairo->cr);
 
     struct cairo_paint paint = {0};

--- a/lib/renderers/cairo.h
+++ b/lib/renderers/cairo.h
@@ -213,10 +213,12 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
     memset(out_result, 0, sizeof(struct cairo_paint_result));
     out_result->displayed = 1;
 
-    cairo_save(cairo->cr);
     cairo_set_source_rgba(cairo->cr, 0, 0, 0, 0);
-    cairo_set_operator(cairo->cr, CAIRO_OPERATOR_SOURCE);
-    cairo_fill(cairo->cr);
+    cairo_rectangle(cairo->cr, 0, 0, width, height);
+
+    cairo_save(cairo->cr);
+    cairo_set_operator(cairo->cr, CAIRO_OPERATOR_CLEAR);
+    cairo_paint(cairo->cr);
     cairo_restore(cairo->cr);
 
     struct cairo_paint paint = {0};

--- a/lib/renderers/cairo.h
+++ b/lib/renderers/cairo.h
@@ -213,9 +213,11 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
     memset(out_result, 0, sizeof(struct cairo_paint_result));
     out_result->displayed = 1;
 
+    cairo_save(cairo->cr);
     cairo_set_source_rgba(cairo->cr, 0, 0, 0, 0);
     cairo_set_operator(cairo->cr, CAIRO_OPERATOR_SOURCE);
     cairo_fill(cairo->cr);
+    cairo_restore(cairo->cr);
 
     struct cairo_paint paint = {0};
     paint.font = menu->font.name;

--- a/lib/renderers/x11/window.c
+++ b/lib/renderers/x11/window.c
@@ -16,7 +16,7 @@ static bool
 create_buffer(struct window *window, struct buffer *buffer, int32_t width, int32_t height)
 {
     cairo_surface_t *surf;
-    if (!(surf = cairo_xlib_surface_create(window->display, window->drawable, DefaultVisual(window->display, window->screen), width, height)))
+    if (!(surf = cairo_xlib_surface_create(window->display, window->drawable, window->visual, width, height)))
         goto fail;
 
     cairo_xlib_surface_set_size(surf, width, height);
@@ -209,6 +209,7 @@ bm_x11_window_create(struct window *window, Display *display)
     window->screen = DefaultScreen(display);
     window->width = window->height = 1;
     window->monitor = -1;
+    window->visual = DefaultVisual(display, window->screen);
 
     XSetWindowAttributes wa = {
         .override_redirect = True,
@@ -217,15 +218,18 @@ bm_x11_window_create(struct window *window, Display *display)
 
     XVisualInfo vinfo;
     int depth = DefaultDepth(display, window->screen);
-    Visual *visual = DefaultVisual(display, window->screen);
+    unsigned long valuemask = CWOverrideRedirect | CWEventMask | CWBackPixel;
 
     if (XMatchVisualInfo(display, DefaultScreen(display), 32, TrueColor, &vinfo)) {
         depth = vinfo.depth;
-        visual = vinfo.visual;
-        wa.colormap = XCreateColormap(display, DefaultRootWindow(display), visual, AllocNone);
+        window->visual = vinfo.visual;
+        wa.background_pixmap = None;
+        wa.border_pixel = 0;
+        wa.colormap = XCreateColormap(display, DefaultRootWindow(display), window->visual, AllocNone);
+        valuemask = CWOverrideRedirect | CWEventMask | CWBackPixmap | CWColormap | CWBorderPixel;
     }
 
-    window->drawable = XCreateWindow(display, DefaultRootWindow(display), 0, 0, window->width, window->height, 0, depth, CopyFromParent, visual, CWOverrideRedirect | CWBackPixel | CWEventMask, &wa);
+    window->drawable = XCreateWindow(display, DefaultRootWindow(display), 0, 0, window->width, window->height, 0, depth, CopyFromParent, window->visual, valuemask, &wa);
     XSelectInput(display, window->drawable, ButtonPressMask | KeyPressMask);
     XMapRaised(display, window->drawable);
     window->xim = XOpenIM(display, NULL, NULL, NULL);

--- a/lib/renderers/x11/window.c
+++ b/lib/renderers/x11/window.c
@@ -94,8 +94,11 @@ bm_x11_window_render(struct window *window, const struct bm_menu *menu)
     }
 
     if (buffer->created) {
+        cairo_save(buffer->cairo.cr);
+        cairo_set_operator(buffer->cairo.cr, CAIRO_OPERATOR_SOURCE);
         cairo_paint(buffer->cairo.cr);
         cairo_surface_flush(buffer->cairo.surface);
+        cairo_restore(buffer->cairo.cr);
     }
 }
 

--- a/lib/renderers/x11/x11.h
+++ b/lib/renderers/x11/x11.h
@@ -24,6 +24,7 @@ struct window {
     Drawable drawable;
     XIM xim;
     XIC xic;
+    Visual *visual;
 
     KeySym keysym;
     uint32_t mods;


### PR DESCRIPTION
This was a much smaller diff than anticipated! Colors are now accepted with or without a fourth pair of hex values for alpha. Without alpha specified, it defaults to FF as you would expect.