### PR TITLE
add soname to shared libraries

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,7 +36,7 @@ wayland: bemenu-renderer-wayland.so
 	$(LINK.c) -c $(filter %.c,$^) $(LDLIBS) -o $@
 
 $(libs): %: VERSION .git/index
-	$(LINK.c) -shared -fPIC $(filter %.c %.a,$^) $(LDLIBS) -o $(addsuffix .$(VERSION), $@)
+	$(LINK.c) -shared -fPIC $(filter %.c %.a,$^) $(LDLIBS) -o $(addsuffix .$(VERSION), $@) -Wl,-soname
 	ln -fs $(addsuffix .$(VERSION), $@) $(addsuffix .$(firstword $(subst ., ,$(VERSION))), $@)
 	ln -fs $(addsuffix .$(VERSION), $@) $@
 


### PR DESCRIPTION
Found in Gentoo QA

* QA Notice: The following shared libraries lack a SONAME
* /usr/lib/libbemenu.so.0.4.0

Signed-off-by: Matthew Thode <mthode@mthode.org>