### PR TITLE
x11,wayland: treat keypad enter as normal enter

### DIFF
--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -118,6 +118,7 @@ poll_key(const struct bm_menu *menu, unsigned int *unicode)
         case XKB_KEY_Insert:
             return BM_KEY_SHIFT_RETURN;
 
+        case XKB_KEY_KP_Enter:
         case XKB_KEY_Return:
             return (mods & MOD_CTRL ? BM_KEY_CONTROL_RETURN : (mods & MOD_SHIFT ? BM_KEY_SHIFT_RETURN : BM_KEY_RETURN));
 

--- a/lib/renderers/x11/x11.c
+++ b/lib/renderers/x11/x11.c
@@ -98,6 +98,7 @@ poll_key(const struct bm_menu *menu, unsigned int *unicode)
         case XK_Insert:
             return BM_KEY_SHIFT_RETURN;
 
+        case XK_KP_Enter:
         case XK_Return:
             return (mods & MOD_CTRL ? BM_KEY_CONTROL_RETURN : (mods & MOD_SHIFT ? BM_KEY_SHIFT_RETURN : BM_KEY_RETURN));
 


### PR DESCRIPTION
Sometimes I'm so lazy that I don't want to reach for the actual enter key on my keyboard, and hit the enter key on my keypad, but that doesn't work. This adds the keypad return key and sets its functionality to be that of a normal enter key.

These changes were really just copy-paste (and some keysym lookups). Let me know if there's something I missed, or something needs to be changed. I can't test this on x11, so I'd appreciate any help in that department.