### PR TITLE
Fix #98

### DIFF
--- a/lib/renderers/wayland/registry.c
+++ b/lib/renderers/wayland/registry.c
@@ -107,8 +107,15 @@ keyboard_handle_leave(void *data, struct wl_keyboard *keyboard, uint32_t serial,
 static void
 press(struct input *input, xkb_keysym_t sym, uint32_t key, enum wl_keyboard_key_state state)
 {
-    input->sym = (state == WL_KEYBOARD_KEY_STATE_PRESSED ? sym : XKB_KEY_NoSymbol);
-    input->code = (state == WL_KEYBOARD_KEY_STATE_PRESSED ? key + 8 : 0);
+
+    if (state == WL_KEYBOARD_KEY_STATE_PRESSED) {
+	    input->sym = sym;
+	    input->code = key + 8;
+	    input->key_pending = true;
+    } else if (!input->key_pending) {
+	    input->sym = XKB_KEY_NoSymbol;
+	    input->code = 0;
+    }
 
     if (input->notify.key)
         input->notify.key(state, sym, key);

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -72,6 +72,10 @@ poll_key(const struct bm_menu *menu, unsigned int *unicode)
     wayland->input.sym = XKB_KEY_NoSymbol;
     wayland->input.code = 0;
 
+    if (!wayland->input.key_pending)
+	    return BM_KEY_UNICODE;
+    wayland->input.key_pending = false;
+
     switch (sym) {
         case XKB_KEY_Up:
             return BM_KEY_UP;
@@ -381,6 +385,7 @@ constructor(struct bm_menu *menu)
     wayland->fds.display = wl_display_get_fd(wayland->display);
     wayland->fds.repeat = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC | TFD_NONBLOCK);
     wayland->input.repeat_fd = &wayland->fds.repeat;
+    wayland->input.key_pending = false;
     recreate_windows(menu, wayland);
 
     if (!efd && (efd = epoll_create1(EPOLL_CLOEXEC)) < 0)

--- a/lib/renderers/wayland/wayland.h
+++ b/lib/renderers/wayland/wayland.h
@@ -65,6 +65,8 @@ struct input {
     struct {
         void (*key)(enum wl_keyboard_key_state state, xkb_keysym_t sym, uint32_t code);
     } notify;
+
+    bool key_pending;
 };
 
 struct buffer {


### PR DESCRIPTION
Add key_pending field to sync wayland keyboard event loops

This fixes #98 

I have tested this out on a wayland environment and can confirm it works well. The basic idea is that the state of input.sym changes with key release only when the poll_key method has already used the value.