### PR TITLE
Wayland: Choose output by name

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -73,13 +73,21 @@ lib/renderers/wayland/wlr-layer-shell-unstable-v1.h: lib/renderers/wayland/wlr-l
 lib/renderers/wayland/wlr-layer-shell-unstable-v1.c: lib/renderers/wayland/wlr-layer-shell-unstable-v1.xml
 	wayland-scanner private-code < $^ > $@
 
+lib/renderers/wayland/xdg-output-unstable-v1.h: lib/renderers/wayland/xdg-output-unstable-v1.xml
+	wayland-scanner client-header < $^ > $@
+
+lib/renderers/wayland/xdg-output-unstable-v1.c: lib/renderers/wayland/xdg-output-unstable-v1.xml
+	wayland-scanner private-code < $^ > $@
+
 xdg-shell.a: private override CPPFLAGS += $(shell pkg-config --cflags-only-I wayland-client)
 xdg-shell.a: lib/renderers/wayland/xdg-shell.c
 wlr-layer-shell.a: private override CPPFLAGS += $(shell pkg-config --cflags-only-I wayland-client)
 wlr-layer-shell.a: lib/renderers/wayland/wlr-layer-shell-unstable-v1.c lib/renderers/wayland/wlr-layer-shell-unstable-v1.h
+xdg-output.a: private override CPPFLAGS += $(shell pkg-config --cflags-only-I wayland-client)
+xdg-output.a: lib/renderers/wayland/xdg-output-unstable-v1.c lib/renderers/wayland/xdg-output-unstable-v1.h
 bemenu-renderer-wayland.so: private override LDLIBS += $(shell pkg-config --libs wayland-client cairo pango pangocairo xkbcommon)
 bemenu-renderer-wayland.so: private override CPPFLAGS += $(shell pkg-config --cflags-only-I wayland-client cairo pango pangocairo xkbcommon)
-bemenu-renderer-wayland.so: lib/renderers/cairo.h lib/renderers/wayland/wayland.c lib/renderers/wayland/wayland.h lib/renderers/wayland/registry.c lib/renderers/wayland/window.c xdg-shell.a wlr-layer-shell.a
+bemenu-renderer-wayland.so: lib/renderers/cairo.h lib/renderers/wayland/wayland.c lib/renderers/wayland/wayland.h lib/renderers/wayland/registry.c lib/renderers/wayland/window.c xdg-shell.a wlr-layer-shell.a xdg-output.a
 
 common.a: client/common/common.c client/common/common.h
 bemenu: common.a client/bemenu.c

--- a/client/common/common.c
+++ b/client/common/common.c
@@ -214,6 +214,22 @@ usage(FILE *out, const char *name)
 }
 
 static void
+set_monitor(struct client *client, char *arg)
+{
+    char *endptr = NULL;
+    long num = strtol(arg, &endptr, 10);
+    if (arg == endptr) { // No digits found
+        if (!strcmp(arg, "all")) {
+            client->monitor = -1;
+        } else {
+            client->monitor_name = arg;
+        }
+    } else {
+        client->monitor = num;
+    }
+}
+
+static void
 do_getopt(struct client *client, int *argc, char **argv[])
 {
     assert(client && argc && argv);
@@ -264,6 +280,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
 
     for (optind = 0;;) {
         int32_t opt;
+
         if ((opt = getopt_long(*argc, *argv, "hviwxl:I:p:P:I:bfm:H:n", opts, NULL)) < 0)
             break;
 
@@ -319,7 +336,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
                 client->grab = true;
                 break;
             case 'm':
-                client->monitor = (!strcmp(optarg, "all") ? -1 : strtol(optarg, NULL, 10));
+                set_monitor(client, optarg);
                 break;
             case 'n':
                 client->no_overlap = true;
@@ -402,7 +419,7 @@ menu_with_options(struct client *client)
     if (!(menu = bm_menu_new(NULL)))
         return NULL;
 
-    client->fork = (client->force_fork || (bm_renderer_get_priorty(bm_menu_get_renderer(menu)) != BM_PRIO_TERMINAL));
+    client->fork = (client->force_fork || (bm_renderer_get_priorty(bm_menu_get_renderer(menu)) != BM_PRIO_TERMINAL)); 
 
     bm_menu_set_font(menu, client->font);
     bm_menu_set_line_height(menu, client->line_height);
@@ -413,6 +430,7 @@ menu_with_options(struct client *client)
     bm_menu_set_wrap(menu, client->wrap);
     bm_menu_set_bottom(menu, client->bottom);
     bm_menu_set_monitor(menu, client->monitor);
+    bm_menu_set_monitor_name(menu, client->monitor_name);
     bm_menu_set_scrollbar(menu, client->scrollbar);
     bm_menu_set_panel_overlap(menu, !client->no_overlap);
     bm_menu_set_password(menu, client->password);

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -24,6 +24,7 @@ struct client {
     bool force_fork, fork;
     bool no_exec;
     bool password;
+    char *monitor_name;
 };
 
 char* cstrcopy(const char *str, size_t size);

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -511,6 +511,15 @@ BM_PUBLIC bool bm_menu_get_bottom(struct bm_menu *menu);
 BM_PUBLIC void bm_menu_set_monitor(struct bm_menu *menu, uint32_t monitor);
 
 /**
+ * Display menu with monitor_name.
+ * Only works for Wayland.
+ *
+ * @param menu bm_menu instance to set monitor for.
+ * @param monitor_name Monitor name passed in.
+ */
+BM_PUBLIC void bm_menu_set_monitor_name(struct bm_menu *menu, char *monitor_name);
+
+/**
  * Return index for current monitor.
  *
  * @param menu bm_menu instance where to get current monitor from.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -85,6 +85,11 @@ struct render_api {
     void (*set_monitor)(const struct bm_menu *menu, uint32_t monitor);
 
     /**
+     * Set monitor name where menu will appear
+     */
+    void (*set_monitor_name)(const struct bm_menu *menu, char *monitor_name);
+
+    /**
      * Grab/Ungrab keyboard
      */
     void (*grab_keyboard)(const struct bm_menu *menu, bool grab);
@@ -285,6 +290,11 @@ struct bm_menu {
      * Current monitor.
      */
     uint32_t monitor;
+
+    /**
+     * Current monitor name. Wayland only.
+     */
+    char *monitor_name;
 
     /**
      * Current filtering method in menu instance.

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -120,6 +120,8 @@ bm_menu_free(struct bm_menu *menu)
     free(menu->old_filter);
     free(menu->font.name);
 
+    free(menu->monitor_name);
+
     for (uint32_t i = 0; i < BM_COLOR_LAST; ++i)
         free(menu->colors[i].hex);
 
@@ -371,6 +373,23 @@ bm_menu_set_monitor(struct bm_menu *menu, uint32_t monitor)
 
     if (menu->renderer->api.set_monitor)
         menu->renderer->api.set_monitor(menu, monitor);
+}
+
+void
+bm_menu_set_monitor_name(struct bm_menu *menu, char *monitor_name)
+{
+    assert(menu);
+
+    if (!monitor_name)
+        return;
+
+    if (menu->monitor_name && !strcmp(menu->monitor_name, monitor_name))
+        return;
+
+    menu->monitor_name = bm_strdup(monitor_name);
+
+    if (menu->renderer->api.set_monitor_name)
+        menu->renderer->api.set_monitor_name(menu, monitor_name);
 }
 
 uint32_t

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -283,11 +283,16 @@ recreate_windows(const struct bm_menu *menu, struct wayland *wayland)
 
     uint32_t monitor = 0;
     wl_list_for_each(output, &wayland->outputs, link) {
-        if (menu->monitor != (uint32_t)-1) {
-            if (menu->monitor < monitors && monitor != menu->monitor) {
-                ++monitor;
-                continue;
+
+        if (!menu->monitor_name) {
+            if (menu->monitor != (uint32_t)-1) {
+                 if (menu->monitor < monitors && monitor != menu->monitor) {
+                    ++monitor;
+                    continue;
+                }
             }
+        } else if (strcmp(menu->monitor_name, output->name)) {
+            continue;
         }
 
         struct wl_surface *surface;
@@ -330,6 +335,15 @@ static void
 set_monitor(const struct bm_menu *menu, uint32_t monitor)
 {
     (void)monitor;
+    struct wayland *wayland = menu->renderer->internal;
+    assert(wayland);
+    recreate_windows(menu, wayland);
+}
+
+static void
+set_monitor_name(const struct bm_menu *menu, char *monitor_name)
+{
+    (void)monitor_name;
     struct wayland *wayland = menu->renderer->internal;
     assert(wayland);
     recreate_windows(menu, wayland);
@@ -419,6 +433,7 @@ register_renderer(struct render_api *api)
     api->grab_keyboard = grab_keyboard;
     api->set_overlap = set_overlap;
     api->set_monitor = set_monitor;
+    api->set_monitor_name = set_monitor_name;    
     api->priorty = BM_PRIO_GUI;
     api->version = BM_PLUGIN_VERSION;
     return "wayland";

--- a/lib/renderers/wayland/wayland.h
+++ b/lib/renderers/wayland/wayland.h
@@ -5,7 +5,7 @@
 #include <xkbcommon/xkbcommon.h>
 
 #include "wlr-layer-shell-unstable-v1.h"
-
+#include "xdg-output-unstable-v1.h"
 #include "renderers/cairo.h"
 
 struct bm_menu;
@@ -96,9 +96,11 @@ struct window {
 
 struct output {
     struct wl_output *output;
+    struct zxdg_output_v1 *xdg_output;
     struct wl_list link;
     int height;
     int scale;
+    char *name;
 };
 
 struct wayland {
@@ -116,6 +118,7 @@ struct wayland {
     struct wl_shm *shm;
     struct input input;
     struct wl_list windows;
+    struct zxdg_output_manager_v1 *xdg_output_manager;
     uint32_t formats;
 };
 

--- a/lib/renderers/wayland/xdg-output-unstable-v1.xml
+++ b/lib/renderers/wayland/xdg-output-unstable-v1.xml
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="xdg_output_unstable_v1">
+
+  <copyright>
+    Copyright © 2017 Red Hat Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol to describe output regions">
+    This protocol aims at describing outputs in a way which is more in line
+    with the concept of an output on desktop oriented systems.
+
+    Some information are more specific to the concept of an output for
+    a desktop oriented system and may not make sense in other applications,
+    such as IVI systems for example.
+
+    Typically, the global compositor space on a desktop system is made of
+    a contiguous or overlapping set of rectangular regions.
+
+    Some of the information provided in this protocol might be identical
+    to their counterparts already available from wl_output, in which case
+    the information provided by this protocol should be preferred to their
+    equivalent in wl_output. The goal is to move the desktop specific
+    concepts (such as output location within the global compositor space,
+    the connector name and types, etc.) out of the core wl_output protocol.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible
+    changes may be added together with the corresponding interface
+    version bump.
+    Backward incompatible changes are done by bumping the version
+    number in the protocol and interface names and resetting the
+    interface version. Once the protocol is to be declared stable,
+    the 'z' prefix and the version number in the protocol and
+    interface names are removed and the interface version number is
+    reset.
+  </description>
+
+  <interface name="zxdg_output_manager_v1" version="3">
+    <description summary="manage xdg_output objects">
+      A global factory interface for xdg_output objects.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_output_manager object">
+	Using this request a client can tell the server that it is not
+	going to use the xdg_output_manager object anymore.
+
+	Any objects already created through this instance are not affected.
+      </description>
+    </request>
+
+    <request name="get_xdg_output">
+      <description summary="create an xdg output from a wl_output">
+	This creates a new xdg_output object for the given wl_output.
+      </description>
+      <arg name="id" type="new_id" interface="zxdg_output_v1"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+  </interface>
+
+  <interface name="zxdg_output_v1" version="3">
+    <description summary="compositor logical output region">
+      An xdg_output describes part of the compositor geometry.
+
+      This typically corresponds to a monitor that displays part of the
+      compositor space.
+
+      For objects version 3 onwards, after all xdg_output properties have been
+      sent (when the object is created and when properties are updated), a
+      wl_output.done event is sent. This allows changes to the output
+      properties to be seen as atomic, even if they happen via multiple events.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_output object">
+	Using this request a client can tell the server that it is not
+	going to use the xdg_output object anymore.
+      </description>
+    </request>
+
+    <event name="logical_position">
+      <description summary="position of the output within the global compositor space">
+	The position event describes the location of the wl_output within
+	the global compositor space.
+
+	The logical_position event is sent after creating an xdg_output
+	(see xdg_output_manager.get_xdg_output) and whenever the location
+	of the output changes within the global compositor space.
+      </description>
+      <arg name="x" type="int"
+	   summary="x position within the global compositor space"/>
+      <arg name="y" type="int"
+	   summary="y position within the global compositor space"/>
+    </event>
+
+    <event name="logical_size">
+      <description summary="size of the output in the global compositor space">
+	The logical_size event describes the size of the output in the
+	global compositor space.
+
+	For example, a surface without any buffer scale, transformation
+	nor rotation set, with the size matching the logical_size will
+	have the same size as the corresponding output when displayed.
+
+	Most regular Wayland clients should not pay attention to the
+	logical size and would rather rely on xdg_shell interfaces.
+
+	Some clients such as Xwayland, however, need this to configure
+	their surfaces in the global compositor space as the compositor
+	may apply a different scale from what is advertised by the output
+	scaling property (to achieve fractional scaling, for example).
+
+	For example, for a wl_output mode 3840×2160 and a scale factor 2:
+
+	- A compositor not scaling the surface buffers will advertise a
+	  logical size of 3840×2160,
+
+	- A compositor automatically scaling the surface buffers will
+	  advertise a logical size of 1920×1080,
+
+	- A compositor using a fractional scale of 1.5 will advertise a
+	  logical size to 2560×1620.
+
+	For example, for a wl_output mode 1920×1080 and a 90 degree rotation,
+	the compositor will advertise a logical size of 1080x1920.
+
+	The logical_size event is sent after creating an xdg_output
+	(see xdg_output_manager.get_xdg_output) and whenever the logical
+	size of the output changes, either as a result of a change in the
+	applied scale or because of a change in the corresponding output
+	mode(see wl_output.mode) or transform (see wl_output.transform).
+      </description>
+      <arg name="width" type="int"
+	   summary="width in global compositor space"/>
+      <arg name="height" type="int"
+	   summary="height in global compositor space"/>
+    </event>
+
+    <event name="done">
+      <description summary="all information about the output have been sent">
+	This event is sent after all other properties of an xdg_output
+	have been sent.
+
+	This allows changes to the xdg_output properties to be seen as
+	atomic, even if they happen via multiple events.
+
+	For objects version 3 onwards, this event is deprecated. Compositors
+	are not required to send it anymore and must send wl_output.done
+	instead.
+      </description>
+    </event>
+
+    <!-- Version 2 additions -->
+
+    <event name="name" since="2">
+      <description summary="name of this output">
+	Many compositors will assign names to their outputs, show them to the
+	user, allow them to be configured by name, etc. The client may wish to
+	know this name as well to offer the user similar behaviors.
+
+	The naming convention is compositor defined, but limited to
+	alphanumeric characters and dashes (-). Each name is unique among all
+	wl_output globals, but if a wl_output global is destroyed the same name
+	may be reused later. The names will also remain consistent across
+	sessions with the same hardware and software configuration.
+
+	Examples of names include 'HDMI-A-1', 'WL-1', 'X11-1', etc. However, do
+	not assume that the name is a reflection of an underlying DRM
+	connector, X11 connection, etc.
+
+	The name event is sent after creating an xdg_output (see
+	xdg_output_manager.get_xdg_output). This event is only sent once per
+	xdg_output, and the name does not change over the lifetime of the
+	wl_output global.
+      </description>
+      <arg name="name" type="string" summary="output name"/>
+    </event>
+
+    <event name="description" since="2">
+      <description summary="human-readable description of this output">
+	Many compositors can produce human-readable descriptions of their
+	outputs.  The client may wish to know this description as well, to
+	communicate the user for various purposes.
+
+	The description is a UTF-8 string with no convention defined for its
+	contents. Examples might include 'Foocorp 11" Display' or 'Virtual X11
+	output via :1'.
+
+	The description event is sent after creating an xdg_output (see
+	xdg_output_manager.get_xdg_output) and whenever the description
+	changes. The description is optional, and may not be sent at all.
+
+	For objects of version 2 and lower, this event is only sent once per
+	xdg_output, and the description does not change over the lifetime of
+	the wl_output global.
+      </description>
+      <arg name="description" type="string" summary="output description"/>
+    </event>
+
+  </interface>
+</protocol>


### PR DESCRIPTION
Allows user to choose the output for bemenu by passing in name with -M flag.

For example:
```
bemenu-run -M eDP-1
```

There might be some cleaning up to do, but overall this works.

Edit:
I should mention I took a lot of the implementation details from [grim](https://github.com/emersion/grim/blob/master/main.c#L350)