### PR TITLE
client: improve stripping of getline(3) newline

### DIFF
--- a/client/bemenu.c
+++ b/client/bemenu.c
@@ -18,10 +18,10 @@ read_items_to_menu_from_stdin(struct bm_menu *menu)
     size_t llen = 0;
     char *line = NULL;
 
-    while ((n = getline(&line, &llen, stdin)) != -1) {
-        // Remove trailing newline
-        assert(n >= 1);
-        line[n - 1] = '\0';
+    while ((n = getline(&line, &llen, stdin)) > 0) {
+        // Remove trailing newline (if any)
+        if (line[n - 1] == '\n')
+            line[n - 1] = '\0';
 
         struct bm_item *item;
         if (!(item = bm_item_new(line)))


### PR DESCRIPTION
The previous version of this code operated under the assumption that
`getline(3)` lines are always `\n\0` terminated. Unfortunately, this is not
the case as readline will return input which is not terminated with a
newline character if EOF is reached before encountering this newline. In
these cases, the code would falsely strip the last character. As an
example, consider the following bemenu invocation:

	printf foo | ./bemenu

This would start bemenu with `fo` instead of `foo` as a menu item. This
commit fixes this edge case and also hardens the loop body a bit by only
entering it if getline wrote more than zero characters to the buffer.

---

Sorry for the inconvenience! :sweat_smile:  