### PR TITLE
x11: Align -m argument interpretation with dmenu

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -278,6 +278,9 @@ do_getopt(struct client *client, int *argc, char **argv[])
      * Either break the interface and make them --sf, --sb (like they are now),
      * or parse them before running getopt.. */
 
+    /* Set default monitor index to -1 (maybe be overwritten with -m below). */
+    client->monitor = -1;
+
     for (optind = 0;;) {
         int32_t opt;
 

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -502,13 +502,13 @@ BM_PUBLIC bool bm_menu_get_bottom(struct bm_menu *menu);
 
 /**
  * Display menu at monitor index.
- * Indices start from 1, pass 0 for active monitor (default).
+ * Indices start at 0, a value of -1 can be passed for the active monitor (default).
  * If index is more than amount of monitors, the monitor with highest index will be selected.
  *
  * @param menu bm_menu instance to set monitor for.
- * @param monitor Monitor index starting from 1.
+ * @param monitor Monitor index starting from 0, or -1 for the active monitor.
  */
-BM_PUBLIC void bm_menu_set_monitor(struct bm_menu *menu, uint32_t monitor);
+BM_PUBLIC void bm_menu_set_monitor(struct bm_menu *menu, int32_t monitor);
 
 /**
  * Display menu with monitor_name.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -82,7 +82,7 @@ struct render_api {
     /**
      * Set monitor indeax where menu will appear
      */
-    void (*set_monitor)(const struct bm_menu *menu, uint32_t monitor);
+    void (*set_monitor)(const struct bm_menu *menu, int32_t monitor);
 
     /**
      * Set monitor name where menu will appear
@@ -289,7 +289,7 @@ struct bm_menu {
     /**
      * Current monitor.
      */
-    uint32_t monitor;
+    int32_t monitor;
 
     /**
      * Current monitor name. Wayland only.

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -362,7 +362,7 @@ bm_menu_get_bottom(struct bm_menu *menu)
 }
 
 void
-bm_menu_set_monitor(struct bm_menu *menu, uint32_t monitor)
+bm_menu_set_monitor(struct bm_menu *menu, int32_t monitor)
 {
     assert(menu);
 

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -276,16 +276,16 @@ recreate_windows(const struct bm_menu *menu, struct wayland *wayland)
 {
     destroy_windows(wayland);
 
-    uint32_t monitors = 0;
+    int32_t monitors = 0;
     struct output *output;
     wl_list_for_each(output, &wayland->outputs, link)
         monitors++;
 
-    uint32_t monitor = 0;
+    int32_t monitor = 0;
     wl_list_for_each(output, &wayland->outputs, link) {
 
         if (!menu->monitor_name) {
-            if (menu->monitor != (uint32_t)-1) {
+            if (menu->monitor != -1) {
                  if (menu->monitor < monitors && monitor != menu->monitor) {
                     ++monitor;
                     continue;
@@ -318,7 +318,7 @@ recreate_windows(const struct bm_menu *menu, struct wayland *wayland)
         window->max_height = output->height;
         window->render_pending = true;
         wl_list_insert(&wayland->windows, &window->link);
-        if (menu->monitor != (uint32_t)-1) break;
+        if (menu->monitor != -1) break;
     }
 
     set_overlap(menu, menu->overlap);
@@ -332,7 +332,7 @@ fail:
 }
 
 static void
-set_monitor(const struct bm_menu *menu, uint32_t monitor)
+set_monitor(const struct bm_menu *menu, int32_t monitor)
 {
     (void)monitor;
     struct wayland *wayland = menu->renderer->internal;

--- a/lib/renderers/x11/window.c
+++ b/lib/renderers/x11/window.c
@@ -131,7 +131,7 @@ bm_x11_window_destroy(struct window *window)
 }
 
 void
-bm_x11_window_set_monitor(struct window *window, uint32_t monitor)
+bm_x11_window_set_monitor(struct window *window, int32_t monitor)
 {
     if (window->monitor == monitor)
         return;
@@ -151,10 +151,9 @@ bm_x11_window_set_monitor(struct window *window, uint32_t monitor)
             XWindowAttributes wa;
 
             XGetInputFocus(window->display, &w, &di);
-            if (monitor > 0)
-                i = ((int32_t)monitor > n ? n : (int32_t)monitor) - 1;
-
-            if (monitor == 0 && w != root && w != PointerRoot && w != None) {
+            if (monitor >= 0 && monitor < n)
+                i = monitor;
+            else if (w != root && w != PointerRoot && w != None) {
                 /* find top-level window containing current input focus */
                 do {
                     if (XQueryTree(window->display, (pw = w), &dw, &w, &dws, &du) && dws)
@@ -172,7 +171,7 @@ bm_x11_window_set_monitor(struct window *window, uint32_t monitor)
             }
 
             /* no focused window is on screen, so use pointer location instead */
-            if (monitor == 0 && !area && XQueryPointer(window->display, root, &dw, &dw, &x, &y, &di, &di, &du)) {
+            if (monitor < 0 && !area && XQueryPointer(window->display, root, &dw, &dw, &x, &y, &di, &di, &du)) {
                 for (i = 0; i < n; i++) {
                     if (INTERSECT(x, y, 1, 1, info[i]) > 0)
                         break;

--- a/lib/renderers/x11/x11.c
+++ b/lib/renderers/x11/x11.c
@@ -204,11 +204,11 @@ set_bottom(const struct bm_menu *menu, bool bottom)
 }
 
 static void
-set_monitor(const struct bm_menu *menu, uint32_t monitor)
+set_monitor(const struct bm_menu *menu, int32_t monitor)
 {
     struct x11 *x11 = menu->renderer->internal;
     assert(x11);
-    bm_x11_window_set_monitor(&x11->window, (monitor != (uint32_t)-1 ? monitor : 0));
+    bm_x11_window_set_monitor(&x11->window, monitor);
 }
 
 static void

--- a/lib/renderers/x11/x11.h
+++ b/lib/renderers/x11/x11.h
@@ -33,7 +33,7 @@ struct window {
     uint32_t x, y, width, height, max_height;
     uint32_t displayed;
 
-    uint32_t monitor;
+    int32_t monitor;
     bool bottom;
 
     struct {
@@ -48,7 +48,7 @@ struct x11 {
 
 void bm_x11_window_render(struct window *window, const struct bm_menu *menu);
 void bm_x11_window_key_press(struct window *window, XKeyEvent *ev);
-void bm_x11_window_set_monitor(struct window *window, uint32_t monitor);
+void bm_x11_window_set_monitor(struct window *window, int32_t monitor);
 void bm_x11_window_set_bottom(struct window *window, bool bottom);
 bool bm_x11_window_create(struct window *window, Display *display);
 void bm_x11_window_destroy(struct window *window);

--- a/man/bemenu.1.in
+++ b/man/bemenu.1.in
@@ -122,15 +122,16 @@ in point size to make each entry.
 Specify the monitor
 .Ar index
 where the list should appear.
-When using the Wayland backend, if
-.Ar index
-is
+Monitor indices start at zero.
+The interpretation of the given argument depends on the utilized backend.
+With X11, a value of
 .Ql -1
-or
+indicates that the current monitor should be used (the default).
+With Wayland, the
+.Ar index
+should be a string specifying a specific monitor name. The value
 .Cm all
-then the list will appear on all monitors.
-The default is
-.Ql 0 .
+indicates that the list should appear on all monitors (the default).
 .It Fl n , -no-overlap Pq Wayland
 Set the
 .Nm


### PR DESCRIPTION
With dmenu, monitor indices start at 0 and a value of -1 (the default)
is used to spawn dmenu on the current monitor. While bemenu strives to
be compatible with dmenu, bemenu monitor indices previously started at 1
and a value of 0 (the default) was used to spawn on the current monitor.

This commit aligns the behaviour of bemenu's x11 backend with dmenu. For
this purposes, the affected code in the x11 backend is synced with the
current dmenu implementation. While doing so the monitor type has also
been switched from a uint32_t to a int32_t.

Fixes #164 

---

TODO:

* [ ] Align behaviour of the wayland backend as well? Presently, the wayland backend uses a value of -1 to display the menu on all monitors while the x11 backend uses -1 to display the menu on the active monitor. Not sure how that should be resolved.
* [x] Change the default monitor value to -1? Presently, 0 is still used (-1 would be a better default, at least for the x11 backend).
* [x] Update documentation in man page.