### PR TITLE
wayland: Allow showing the menu on the focused monitor

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -219,8 +219,10 @@ set_monitor(struct client *client, char *arg)
     char *endptr = NULL;
     long num = strtol(arg, &endptr, 10);
     if (arg == endptr) { // No digits found
-        if (!strcmp(arg, "all")) {
+        if (!strcmp(arg, "focused")) {
             client->monitor = -1;
+        } else if (!strcmp(arg, "all")) {
+            client->monitor = -2;
         } else {
             client->monitor_name = arg;
         }

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -285,7 +285,7 @@ recreate_windows(const struct bm_menu *menu, struct wayland *wayland)
     wl_list_for_each(output, &wayland->outputs, link) {
 
         if (!menu->monitor_name) {
-            if (menu->monitor != -1) {
+            if (menu->monitor > -1) {
                  if (menu->monitor < monitors && monitor != menu->monitor) {
                     ++monitor;
                     continue;
@@ -311,14 +311,14 @@ recreate_windows(const struct bm_menu *menu, struct wayland *wayland)
             window->scale = output->scale;
         }
 
-        if (!bm_wl_window_create(window, wayland->display, wayland->shm, output->output, wayland->layer_shell, surface))
+        if (!bm_wl_window_create(window, wayland->display, wayland->shm, (menu->monitor == -1) ? NULL : output->output, wayland->layer_shell, surface))
             free(window);
 
         window->notify.render = bm_cairo_paint;
         window->max_height = output->height;
         window->render_pending = true;
         wl_list_insert(&wayland->windows, &window->link);
-        if (menu->monitor != -1) break;
+        if (menu->monitor != -2) break;
     }
 
     set_overlap(menu, menu->overlap);

--- a/lib/renderers/wayland/wlr-layer-shell-unstable-v1.xml
+++ b/lib/renderers/wayland/wlr-layer-shell-unstable-v1.xml
@@ -25,7 +25,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zwlr_layer_shell_v1" version="1">
+  <interface name="zwlr_layer_shell_v1" version="4">
     <description summary="create surfaces that are layers of the desktop">
       Clients can use this interface to assign the surface_layer role to
       wl_surfaces. Such surfaces are assigned to a "layer" of the output and
@@ -47,12 +47,22 @@
         or manipulate a buffer prior to the first layer_surface.configure call
         must also be treated as errors.
 
+        After creating a layer_surface object and setting it up, the client
+        must perform an initial commit without any buffer attached.
+        The compositor will reply with a layer_surface.configure event.
+        The client must acknowledge it and is then allowed to attach a buffer
+        to map the surface.
+
+        You may pass NULL for output to allow the compositor to decide which
+        output to use. Generally this will be the one that the user most
+        recently interacted with.
+
         Clients can specify a namespace that defines the purpose of the layer
         surface.
       </description>
       <arg name="id" type="new_id" interface="zwlr_layer_surface_v1"/>
       <arg name="surface" type="object" interface="wl_surface"/>
-      <arg name="output" type="object" interface="wl_output"/>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
       <arg name="layer" type="uint" enum="layer" summary="layer to add this surface to"/>
       <arg name="namespace" type="string" summary="namespace for the layer surface"/>
     </request>
@@ -78,17 +88,35 @@
       <entry name="top" value="2"/>
       <entry name="overlay" value="3"/>
     </enum>
+
+    <!-- Version 3 additions -->
+
+    <request name="destroy" type="destructor" since="3">
+      <description summary="destroy the layer_shell object">
+        This request indicates that the client will not use the layer_shell
+        object any more. Objects that have been created through this instance
+        are not affected.
+      </description>
+    </request>
   </interface>
 
-  <interface name="zwlr_layer_surface_v1" version="1">
+  <interface name="zwlr_layer_surface_v1" version="4">
     <description summary="layer metadata interface">
       An interface that may be implemented by a wl_surface, for surfaces that
       are designed to be rendered as a layer of a stacked desktop-like
       environment.
 
-      Layer surface state (size, anchor, exclusive zone, margin, interactivity)
-      is double-buffered, and will be applied at the time wl_surface.commit of
-      the corresponding wl_surface is called.
+      Layer surface state (layer, size, anchor, exclusive zone,
+      margin, interactivity) is double-buffered, and will be applied at the
+      time wl_surface.commit of the corresponding wl_surface is called.
+
+      Attaching a null buffer to a layer surface unmaps it.
+
+      Unmapping a layer_surface means that the surface cannot be shown by the
+      compositor until it is explicitly mapped again. The layer_surface
+      returns to the state it had right after layer_shell.get_layer_surface.
+      The client can re-map the surface by performing a commit without any
+      buffer attached, waiting for a configure event and handling it as usual.
     </description>
 
     <request name="set_size">
@@ -111,7 +139,7 @@
     <request name="set_anchor">
       <description summary="configures the anchor point of the surface">
         Requests that the compositor anchor the surface to the specified edges
-        and corners. If two orthoginal edges are specified (e.g. 'top' and
+        and corners. If two orthogonal edges are specified (e.g. 'top' and
         'left'), then the anchor point will be the intersection of the edges
         (e.g. the top left corner of the output); otherwise the anchor point
         will be centered on that edge, or in the center if none is specified.
@@ -123,20 +151,25 @@
 
     <request name="set_exclusive_zone">
       <description summary="configures the exclusive geometry of this surface">
-        Requests that the compositor avoids occluding an area of the surface
-        with other surfaces. The compositor's use of this information is
+        Requests that the compositor avoids occluding an area with other
+        surfaces. The compositor's use of this information is
         implementation-dependent - do not assume that this region will not
         actually be occluded.
 
-        A positive value is only meaningful if the surface is anchored to an
-        edge, rather than a corner. The zone is the number of surface-local
-        coordinates from the edge that are considered exclusive.
+        A positive value is only meaningful if the surface is anchored to one
+        edge or an edge and both perpendicular edges. If the surface is not
+        anchored, anchored to only two perpendicular edges (a corner), anchored
+        to only two parallel edges or anchored to all edges, a positive value
+        will be treated the same as zero.
+
+        A positive zone is the distance from the edge in surface-local
+        coordinates to consider exclusive.
 
         Surfaces that do not wish to have an exclusive zone may instead specify
         how they should interact with surfaces that do. If set to zero, the
         surface indicates that it would like to be moved to avoid occluding
-        surfaces with a positive excluzive zone. If set to -1, the surface
-        indicates that it would not like to be moved to accomodate for other
+        surfaces with a positive exclusive zone. If set to -1, the surface
+        indicates that it would not like to be moved to accommodate for other
         surfaces, and the compositor should extend it all the way to the edges
         it is anchored to.
 
@@ -170,21 +203,85 @@
       <arg name="left" type="int"/>
     </request>
 
+    <enum name="keyboard_interactivity">
+      <description summary="types of keyboard interaction possible for a layer shell surface">
+        Types of keyboard interaction possible for layer shell surfaces. The
+        rationale for this is twofold: (1) some applications are not interested
+        in keyboard events and not allowing them to be focused can improve the
+        desktop experience; (2) some applications will want to take exclusive
+        keyboard focus.
+      </description>
+
+      <entry name="none" value="0">
+        <description summary="no keyboard focus is possible">
+          This value indicates that this surface is not interested in keyboard
+          events and the compositor should never assign it the keyboard focus.
+
+          This is the default value, set for newly created layer shell surfaces.
+
+          This is useful for e.g. desktop widgets that display information or
+          only have interaction with non-keyboard input devices.
+        </description>
+      </entry>
+      <entry name="exclusive" value="1">
+        <description summary="request exclusive keyboard focus">
+          Request exclusive keyboard focus if this surface is above the shell surface layer.
+
+          For the top and overlay layers, the seat will always give
+          exclusive keyboard focus to the top-most layer which has keyboard
+          interactivity set to exclusive. If this layer contains multiple
+          surfaces with keyboard interactivity set to exclusive, the compositor
+          determines the one receiving keyboard events in an implementation-
+          defined manner. In this case, no guarantee is made when this surface
+          will receive keyboard focus (if ever).
+
+          For the bottom and background layers, the compositor is allowed to use
+          normal focus semantics.
+
+          This setting is mainly intended for applications that need to ensure
+          they receive all keyboard events, such as a lock screen or a password
+          prompt.
+        </description>
+      </entry>
+      <entry name="on_demand" value="2" since="4">
+        <description summary="request regular keyboard focus semantics">
+          This requests the compositor to allow this surface to be focused and
+          unfocused by the user in an implementation-defined manner. The user
+          should be able to unfocus this surface even regardless of the layer
+          it is on.
+
+          Typically, the compositor will want to use its normal mechanism to
+          manage keyboard focus between layer shell surfaces with this setting
+          and regular toplevels on the desktop layer (e.g. click to focus).
+          Nevertheless, it is possible for a compositor to require a special
+          interaction to focus or unfocus layer shell surfaces (e.g. requiring
+          a click even if focus follows the mouse normally, or providing a
+          keybinding to switch focus between layers).
+
+          This setting is mainly intended for desktop shell components (e.g.
+          panels) that allow keyboard interaction. Using this option can allow
+          implementing a desktop shell that can be fully usable without the
+          mouse.
+        </description>
+      </entry>
+    </enum>
+
     <request name="set_keyboard_interactivity">
       <description summary="requests keyboard events">
-        Set to 1 to request that the seat send keyboard events to this layer
-        surface. For layers below the shell surface layer, the seat will use
-        normal focus semantics. For layers above the shell surface layers, the
-        seat will always give exclusive keyboard focus to the top-most layer
-        which has keyboard interactivity set to true.
+        Set how keyboard events are delivered to this surface. By default,
+        layer shell surfaces do not receive keyboard events; this request can
+        be used to change this.
+
+        This setting is inherited by child surfaces set by the get_popup
+        request.
 
         Layer surfaces receive pointer, touch, and tablet events normally. If
         you do not want to receive them, set the input region on your surface
         to an empty region.
 
-        Events is double-buffered, see wl_surface.commit.
+        Keyboard interactivity is double-buffered, see wl_surface.commit.
       </description>
-      <arg name="keyboard_interactivity" type="uint"/>
+      <arg name="keyboard_interactivity" type="uint" enum="keyboard_interactivity"/>
     </request>
 
     <request name="get_popup">
@@ -269,6 +366,7 @@
       <entry name="invalid_surface_state" value="0" summary="provided surface state is invalid"/>
       <entry name="invalid_size" value="1" summary="size is invalid"/>
       <entry name="invalid_anchor" value="2" summary="anchor bitfield is invalid"/>
+      <entry name="invalid_keyboard_interactivity" value="3" summary="keyboard interactivity is invalid"/>
     </enum>
 
     <enum name="anchor" bitfield="true">
@@ -277,5 +375,16 @@
       <entry name="left" value="4" summary="the left edge of the anchor rectangle"/>
       <entry name="right" value="8" summary="the right edge of the anchor rectangle"/>
     </enum>
+
+    <!-- Version 2 additions -->
+
+    <request name="set_layer" since="2">
+      <description summary="change the layer of the surface">
+        Change the layer that the surface is rendered on.
+
+        Layer is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="layer" type="uint" enum="zwlr_layer_shell_v1.layer" summary="layer to move this surface to"/>
+    </request>
   </interface>
 </protocol>

--- a/man/bemenu.1.in
+++ b/man/bemenu.1.in
@@ -124,14 +124,18 @@ Specify the monitor
 where the list should appear.
 Monitor indices start at zero.
 The interpretation of the given argument depends on the utilized backend.
-With X11, a value of
+With X11 and Wayland, a value of
 .Ql -1
+or
+.Cm focused
 indicates that the current monitor should be used (the default).
 With Wayland, the
 .Ar index
 should be a string specifying a specific monitor name. The value
+.Ql -2
+or
 .Cm all
-indicates that the list should appear on all monitors (the default).
+indicates that the list should appear on all monitors.
 .It Fl n , -no-overlap Pq Wayland
 Set the
 .Nm


### PR DESCRIPTION
This adds an alias 'focused' for selecting the current monitor, which
becomes the default on x11 and wayland. The previous wayland default of
displaying on all outputs moves under '-2' or 'all'.

ref: https://github.com/Cloudef/bemenu/issues/102#issuecomment-604562234

Signed-off-by: Robert Günzler <r@gnzler.io>