### PR TITLE
Handle multiple seats (more) correctly

### DIFF
--- a/lib/renderers/wayland/registry.c
+++ b/lib/renderers/wayland/registry.c
@@ -215,11 +215,13 @@ seat_handle_capabilities(void *data, struct wl_seat *seat, enum wl_seat_capabili
 {
     struct input *input = data;
 
-    if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && !input->keyboard) {
+    if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && !input->seat) {
+        input->seat = seat;
         input->keyboard = wl_seat_get_keyboard(seat);
         wl_keyboard_add_listener(input->keyboard, &keyboard_listener, data);
-    } else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) && input->keyboard) {
+    } else if (seat == input->seat && !(caps & WL_SEAT_CAPABILITY_KEYBOARD)) {
         wl_keyboard_destroy(input->keyboard);
+        input->seat = NULL;
         input->keyboard = NULL;
     }
 }

--- a/lib/renderers/wayland/wayland.h
+++ b/lib/renderers/wayland/wayland.h
@@ -46,6 +46,7 @@ struct xkb {
 struct input {
     int *repeat_fd;
 
+    struct wl_seat *seat;
     struct wl_keyboard *keyboard;
     struct xkb xkb;
 


### PR DESCRIPTION
Previously, any seat without a keyboard could destroy our selected
keyboard. Now, select by seat instead and only destroy the keyboard if
it vanishes from that seat. This isn't actually multi-seat support, but
at least it will allow bemenu to accept input.