### PR TITLE
Ignore hidden files in `bemenu`

### DIFF
--- a/client/bemenu-run.c
+++ b/client/bemenu-run.c
@@ -90,7 +90,7 @@ read_items_to_menu_from_dir(struct bm_menu *menu, const char *path)
 
     struct dirent *file;
     while ((file = readdir(dir))) {
-        if (file->d_type != DT_DIR && strlen(file->d_name)) {
+        if (file->d_type != DT_DIR && strlen(file->d_name) && file->d_name[0] != '.') {
             struct bm_item *item;
             if (!(item = bm_item_new(file->d_name)))
                 break;


### PR DESCRIPTION
On most systems it's fairly uncommon to have hidden files within
`$PATH`, but in case of NixOS this is fairly regularly the case as we
have the convention to add `foo` and `.foo-wrapped` to a `bin`-directory
if `foo` is supposed to be a wrapper which sets e.g. env-vars for the
program.

These `.foo-wrapped`-executables are almost never needed, but are shown
in `bemenu` right at the start, so I modified the selection code to skip
hidden files which is also what `dmenu` does for instance.