### PR TITLE
fix scaling caused issue on window redimension on wayland

### DIFF
--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -236,10 +236,10 @@ bm_wl_window_render(struct window *window, struct wl_display *display, const str
         window->notify.render(&buffer->cairo, buffer->width, window->max_height, menu, &result);
         window->displayed = result.displayed;
 
-        if (window->height == result.height)
+        if (window->height == result.height / window->scale)
             break;
 
-        window->height = result.height;
+        window->height = result.height / window->scale;
         zwlr_layer_surface_v1_set_size(window->layer_surface, 0, window->height);
         wl_surface_commit(window->surface);
         wl_display_roundtrip(display);


### PR DESCRIPTION
This caused issue when using the -b (bottom) and -l (line) arguments on
scaled outputs.

When using a scaled output, the set_size use a wrong value as height.
We generated a scalled buffer so we used a scale x too high size.

We just have to divide the scaling to use a good size.