### PR TITLE
mouse and touch support on wayland

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -212,6 +212,8 @@ usage(FILE *out, const char *name)
           " --nf                  defines the normal foreground color. (wx)\n"
           " --hb                  defines the highlighted background color. (wx)\n"
           " --hf                  defines the highlighted foreground color. (wx)\n"
+          " --fbb                 defines the feedback background color. (wx)\n"
+          " --fbf                 defines the feedback foreground color. (wx)\n"
           " --sb                  defines the selected background color. (wx)\n"
           " --sf                  defines the selected foreground color. (wx)\n"
           " --scb                 defines the scrollbar background color. (wx)\n"
@@ -257,10 +259,9 @@ do_getopt(struct client *client, int *argc, char **argv[])
         { "prefix",       required_argument, 0, 'P' },
         { "password",     no_argument,       0, 'x' },
         { "scrollbar",    required_argument, 0, 0x100 },
-        { "ifne",         no_argument,       0, 0x115 },
-        { "fork",         no_argument,       0, 0x116 },
-        { "no-exec",      no_argument,       0, 0x117 },
-
+        { "ifne",         no_argument,       0, 0x117 },
+        { "fork",         no_argument,       0, 0x118 },
+        { "no-exec",      no_argument,       0, 0x119 },
         { "bottom",       no_argument,       0, 'b' },
         { "grab",         no_argument,       0, 'f' },
         { "no-overlap",   no_argument,       0, 'n' },
@@ -279,12 +280,14 @@ do_getopt(struct client *client, int *argc, char **argv[])
         { "nf",           required_argument, 0, 0x107 },
         { "hb",           required_argument, 0, 0x108 },
         { "hf",           required_argument, 0, 0x109 },
-        { "sb",           required_argument, 0, 0x110 },
-        { "sf",           required_argument, 0, 0x111 },
-        { "scb",          required_argument, 0, 0x112 },
-        { "scf",          required_argument, 0, 0x113 },
+        { "fbb",          required_argument, 0, 0x110 },
+        { "fbf",          required_argument, 0, 0x111 },
+        { "sb",           required_argument, 0, 0x112 },
+        { "sf",           required_argument, 0, 0x113 },
+        { "scb",          required_argument, 0, 0x114 },
+        { "scf",          required_argument, 0, 0x115 },
 
-        { "disco",       no_argument,       0, 0x114 },
+        { "disco",       no_argument,       0, 0x116 },
         { 0, 0, 0, 0 }
     };
 
@@ -336,13 +339,13 @@ do_getopt(struct client *client, int *argc, char **argv[])
             case 0x100:
                 client->scrollbar = (!strcmp(optarg, "none") ? BM_SCROLLBAR_NONE : (!strcmp(optarg, "always") ? BM_SCROLLBAR_ALWAYS : (!strcmp(optarg, "autohide") ? BM_SCROLLBAR_AUTOHIDE : BM_SCROLLBAR_NONE)));
                 break;
-            case 0x115:
+            case 0x117:
                 client->ifne = true;
                 break;
-            case 0x116:
+            case 0x118:
                 client->force_fork = true;
                 break;
-            case 0x117:
+            case 0x119:
                 client->no_exec = true;
                 break;
             case 'x':
@@ -374,7 +377,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
             case 'W':
                 client->width_factor = strtof(optarg, NULL);
                 break;
-            case 0x118:
+            case 0x120:
                 client->cursor_height = strtol(optarg, NULL, 10);
                 break;
             case 0x101:
@@ -405,19 +408,25 @@ do_getopt(struct client *client, int *argc, char **argv[])
                 client->colors[BM_COLOR_HIGHLIGHTED_FG] = optarg;
                 break;
             case 0x110:
-                client->colors[BM_COLOR_SELECTED_BG] = optarg;
+                client->colors[BM_COLOR_FEEDBACK_BG] = optarg;
                 break;
             case 0x111:
-                client->colors[BM_COLOR_SELECTED_FG] = optarg;
+                client->colors[BM_COLOR_FEEDBACK_FG] = optarg;
                 break;
             case 0x112:
-                client->colors[BM_COLOR_SCROLLBAR_BG] = optarg;
+                client->colors[BM_COLOR_SELECTED_BG] = optarg;
                 break;
             case 0x113:
+                client->colors[BM_COLOR_SELECTED_FG] = optarg;
+                break;
+            case 0x114:
+                client->colors[BM_COLOR_SCROLLBAR_BG] = optarg;
+                break;
+            case 0x115:
                 client->colors[BM_COLOR_SCROLLBAR_FG] = optarg;
                 break;
 
-            case 0x114:
+            case 0x116:
                 disco();
                 break;
 

--- a/client/common/common.c
+++ b/client/common/common.c
@@ -502,11 +502,15 @@ run_menu(const struct client *client, struct bm_menu *menu, void (*item_cb)(cons
 
     uint32_t unicode;
     enum bm_key key;
+    struct bm_pointer pointer;
+    struct bm_touch touch;
     enum bm_run_result status = BM_RUN_RESULT_RUNNING;
     do {
         bm_menu_render(menu);
         key = bm_menu_poll_key(menu, &unicode);
-    } while ((status = bm_menu_run_with_key(menu, key, unicode)) == BM_RUN_RESULT_RUNNING);
+        pointer = bm_menu_poll_pointer(menu);
+        touch = bm_menu_poll_touch(menu);
+    } while ((status = bm_menu_run_with_events(menu, key, pointer, touch, unicode)) == BM_RUN_RESULT_RUNNING);
 
     switch (status) {
         case BM_RUN_RESULT_SELECTED:

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -317,6 +317,14 @@ struct bm_touch {
     struct bm_touch_point points[2];
 };
 
+enum bm_event_feedback_mask {
+    TOUCH_WILL_SCROLL_UP = 1 << 1,
+    TOUCH_WILL_SCROLL_DOWN = 1 << 2,
+    TOUCH_WILL_SCROLL_FIRST = 1 << 3,
+    TOUCH_WILL_SCROLL_LAST = 1 << 4,
+    TOUCH_WILL_CANCEL = 1 << 5,
+};
+
 /**
  * Colorable element constants.
  *
@@ -331,6 +339,8 @@ enum bm_color {
     BM_COLOR_ITEM_FG,
     BM_COLOR_HIGHLIGHTED_BG,
     BM_COLOR_HIGHLIGHTED_FG,
+    BM_COLOR_FEEDBACK_BG,
+    BM_COLOR_FEEDBACK_FG,
     BM_COLOR_SELECTED_BG,
     BM_COLOR_SELECTED_FG,
     BM_COLOR_SCROLLBAR_BG,

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -253,6 +253,70 @@ enum bm_key {
     BM_KEY_LAST
 };
 
+enum bm_pointer_key {
+    BM_POINTER_KEY_NONE,
+    BM_POINTER_KEY_PRIMARY,
+};
+
+enum bm_pointer_axis {
+    BM_POINTER_AXIS_VERTICAL = 0,
+    BM_POINTER_AXIS_HORIZONTAL = 1,
+};
+
+enum bm_pointer_event_mask {
+    POINTER_EVENT_ENTER = 1 << 1,
+    POINTER_EVENT_LEAVE = 1 << 2,
+    POINTER_EVENT_MOTION = 1 << 3,
+    POINTER_EVENT_BUTTON = 1 << 4,
+    POINTER_EVENT_AXIS = 1 << 5,
+    POINTER_EVENT_AXIS_SOURCE = 1 << 6,
+    POINTER_EVENT_AXIS_STOP = 1 << 7,
+    POINTER_EVENT_AXIS_DISCRETE = 1 << 8,
+};
+
+enum bm_pointer_state_mask {
+    POINTER_STATE_RELEASED,
+    POINTER_STATE_PRESSED,
+};
+
+struct bm_pointer {
+    uint32_t event_mask;
+    uint32_t pos_x, pos_y;
+    uint32_t button, state;
+    uint32_t time;
+    struct {
+        bool valid;
+        int32_t value;
+        int32_t discrete;
+    } axes[2];
+    uint32_t axis_source;
+};
+
+enum bm_touch_event_mask {
+    TOUCH_EVENT_DOWN = 1 << 0,
+    TOUCH_EVENT_UP = 1 << 1,
+    TOUCH_EVENT_MOTION = 1 << 2,
+    TOUCH_EVENT_CANCEL = 1 << 3,
+    TOUCH_EVENT_SHAPE = 1 << 4,
+    TOUCH_EVENT_ORIENTATION = 1 << 5,
+};
+
+struct bm_touch_point {
+    bool valid;
+    int32_t id;
+    uint32_t event_mask;
+    int32_t start_x, start_y;
+    int32_t pos_x, pos_y;
+    uint32_t major, minor;
+    uint32_t orientation;
+};
+
+struct bm_touch {
+    uint32_t time;
+    uint32_t serial;
+    struct bm_touch_point points[2];
+};
+
 /**
  * Colorable element constants.
  *
@@ -485,6 +549,22 @@ BM_PUBLIC void bm_menu_set_cursor_height(struct bm_menu *menu, uint32_t cursor_h
  * @return uint32_t for max amount of vertical cursors to be shown.
  */
 BM_PUBLIC uint32_t bm_menu_get_cursor_height(struct bm_menu *menu);
+
+/**
+ * Get with of menu in pixels.
+ *
+ * @param menu bm_menu instance where to get line height.
+ * @return uint32_t for max amount the menu height.
+ */
+BM_PUBLIC uint32_t bm_menu_get_height(struct bm_menu *menu);
+
+/**
+ * Get with of menu in pixels.
+ *
+ * @param menu bm_menu instance where to get line width.
+ * @return uint32_t for max amount the menu width.
+ */
+BM_PUBLIC uint32_t bm_menu_get_width(struct bm_menu *menu);
 
 /**
  * Set a hexadecimal color for element.
@@ -810,14 +890,43 @@ BM_PUBLIC void bm_menu_filter(struct bm_menu *menu);
 BM_PUBLIC enum bm_key bm_menu_poll_key(struct bm_menu *menu, uint32_t *out_unicode);
 
 /**
+ * Poll pointer and unicode from underlying UI toolkit.
+ *
+ * This function will block on **curses** renderer.
+ *
+ * @param menu bm_menu instance from which to poll.
+ * @return bm_pointer for polled pointer.
+ */
+BM_PUBLIC struct bm_pointer bm_menu_poll_pointer(struct bm_menu *menu);
+
+/**
+ * Poll touch and unicode from underlying UI toolkit.
+ *
+ * This function will block on **curses** renderer.
+ *
+ * @param menu bm_menu instance from which to poll.
+ * @return bm_touch for polled touch.
+ */
+BM_PUBLIC struct bm_touch bm_menu_poll_touch(struct bm_menu *menu);
+
+/**
+ * Enforce a release of the touches.
+ *
+ * @param menu bm_menu instance from which to poll.
+ */
+BM_PUBLIC void bm_menu_release_touch(struct bm_menu *menu);
+
+/**
  * Advances menu logic with key and unicode as input.
  *
  * @param menu bm_menu instance to be advanced.
  * @param key Key input that will advance menu logic.
+ * @param pointer Pointer input that will advance menu logic.
+ * @param touch Touch input that will advance menu logic.
  * @param unicode Unicode input that will advance menu logic.
  * @return bm_run_result for menu state.
  */
-BM_PUBLIC enum bm_run_result bm_menu_run_with_key(struct bm_menu *menu, enum bm_key key, uint32_t unicode);
+BM_PUBLIC enum bm_run_result bm_menu_run_with_events(struct bm_menu *menu, enum bm_key key, struct bm_pointer pointer, struct bm_touch touch, uint32_t unicode);
 
 /**  @} Menu Logic */
 

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -875,7 +875,7 @@ BM_PUBLIC struct bm_item** bm_menu_get_filtered_items(const struct bm_menu *menu
  *
  * @param menu bm_menu instance to be rendered.
  */
-BM_PUBLIC void bm_menu_render(const struct bm_menu *menu);
+BM_PUBLIC void bm_menu_render(struct bm_menu *menu);
 
 /**
  * Trigger filtering of menu manually.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -103,7 +103,7 @@ struct render_api {
     /**
      * Tells underlying renderer to draw the menu.
      */
-    void (*render)(const struct bm_menu *menu);
+    void (*render)(struct bm_menu *menu);
 
     /**
      * Set vertical alignment of the bar.
@@ -391,6 +391,11 @@ struct bm_menu {
      * Mask representing a feedback to bring to user
      */
     uint32_t event_feedback;
+
+    /**
+     * Is the menu needing a redraw ?
+     */
+    bool dirty;
 };
 
 /* library.c */

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -386,6 +386,11 @@ struct bm_menu {
      * Should the entry should follow the title spacing
      */
     bool spacing;
+
+    /**
+     * Mask representing a feedback to bring to user
+     */
+    uint32_t event_feedback;
 };
 
 /* library.c */

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -67,10 +67,38 @@ struct render_api {
     uint32_t (*get_displayed_count)(const struct bm_menu *menu);
 
     /**
+     * Get height by the underlying renderer;
+     */
+    uint32_t (*get_height)(const struct bm_menu *menu);
+
+    /**
+     * Get width by the underlying renderer;
+     */
+    uint32_t (*get_width)(const struct bm_menu *menu);
+
+    /**
      * If the underlying renderer is a UI toolkit. (curses, etc...)
      * There might be possibility to get user input, and this should be thus implemented.
      */
     enum bm_key (*poll_key)(const struct bm_menu *menu, uint32_t *unicode);
+
+    /**
+     * If the underlying renderer is a UI toolkit. (curses, etc...)
+     * There might be possibility to get user pointer, and this should be thus implemented.
+     */
+    struct bm_pointer (*poll_pointer)(const struct bm_menu *menu);
+
+    /**
+     * If the underlying renderer is a UI toolkit. (curses, etc...)
+     * There might be possibility to get user touch, and this should be thus implemented.
+     */
+    struct bm_touch (*poll_touch)(const struct bm_menu *menu);
+
+    /**
+     * Enforce a release of the touches
+     * There might be possibility to get user touch, and this should be thus implemented.
+     */
+    void (*release_touch)(const struct bm_menu *menu);
 
     /**
      * Tells underlying renderer to draw the menu.

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -802,12 +802,23 @@ static void
 menu_point_select(struct bm_menu *menu, uint32_t posx, uint32_t posy, uint32_t displayed)
 {
     (void) posx;
-    uint32_t selected_line = posy / (bm_menu_get_height(menu) / displayed);
-    uint16_t current_page_index = menu->index / menu->lines;
+
+    if (displayed == 0) {
+        return;
+    }
+    uint32_t line_height = bm_menu_get_height(menu) / displayed;
+
+    if (line_height == 0) {
+        return;
+    }
+    uint32_t selected_line = posy / line_height;
 
     if (0 == selected_line) { // Mouse over title bar
         return;
     }
+
+    assert(menu->lines != 0);
+    uint16_t current_page_index = menu->index / menu->lines;
 
     if (selected_line >= displayed) { // This might be useless
         return;
@@ -819,6 +830,7 @@ menu_point_select(struct bm_menu *menu, uint32_t posx, uint32_t posy, uint32_t d
 static void
 menu_scroll_down(struct bm_menu *menu, uint16_t count)
 {
+    assert(menu->lines != 0);
     if (menu->index / menu->lines != count / menu->lines) { // not last page
         bm_menu_set_highlighted_index(menu, ((menu->index / menu->lines) + 1) * menu->lines);
     }
@@ -828,6 +840,7 @@ static void
 menu_scroll_up(struct bm_menu *menu, uint16_t count)
 {
     (void) count;
+    assert(menu->lines != 0);
     if (menu->index / menu->lines) { // not first page
         bm_menu_set_highlighted_index(menu, ((menu->index / menu->lines) - 1) * menu->lines + menu->lines - 1);
     }

--- a/lib/renderers/curses/curses.c
+++ b/lib/renderers/curses/curses.c
@@ -177,7 +177,7 @@ draw_line(int32_t pair, int32_t y, const char *fmt, ...)
 }
 
 static void
-render(const struct bm_menu *menu)
+render(struct bm_menu *menu)
 {
     if (curses.should_terminate) {
         terminate();

--- a/lib/renderers/wayland/registry.c
+++ b/lib/renderers/wayland/registry.c
@@ -695,7 +695,6 @@ bm_wl_registry_register(struct wayland *wayland)
         return false;
 
     set_repeat_info(&wayland->input, 40, 400);
-    wayland->input.last_code = 0xDEADBEEF;
     return true;
 }
 

--- a/lib/renderers/wayland/wayland.h
+++ b/lib/renderers/wayland/wayland.h
@@ -90,7 +90,6 @@ struct input {
 
     xkb_keysym_t sym;
     uint32_t code;
-    uint32_t last_code;
     uint32_t modifiers;
 
     xkb_keysym_t repeat_sym;

--- a/lib/renderers/wayland/wayland.h
+++ b/lib/renderers/wayland/wayland.h
@@ -5,6 +5,7 @@
 
 #include <wayland-client.h>
 #include <xkbcommon/xkbcommon.h>
+#include <linux/input-event-codes.h>
 
 #include "wlr-layer-shell-unstable-v1.h"
 #include "xdg-output-unstable-v1.h"
@@ -45,11 +46,46 @@ struct xkb {
     xkb_mod_mask_t masks[MASK_LAST];
 };
 
+struct pointer_event {
+    uint32_t event_mask;
+    wl_fixed_t surface_x, surface_y;
+    uint32_t button, state;
+    uint32_t time;
+    uint32_t serial;
+    struct {
+        bool valid;
+        wl_fixed_t value;
+        int32_t discrete;
+    } axes[2];
+    uint32_t axis_source;
+};
+
+struct touch_point {
+    bool valid;
+    int32_t id;
+    uint32_t event_mask;
+    wl_fixed_t surface_x, surface_y;
+    wl_fixed_t surface_start_x, surface_start_y;
+    wl_fixed_t major, minor;
+    wl_fixed_t orientation;
+};
+
+struct touch_event {
+    uint32_t time;
+    uint32_t serial;
+    uint16_t active;
+    struct touch_point points[2];
+};
+
 struct input {
     int *repeat_fd;
 
     struct wl_seat *seat;
     struct wl_keyboard *keyboard;
+    struct wl_pointer *pointer;
+    struct wl_touch *touch;
+    struct pointer_event pointer_event;
+    struct touch_event touch_event;
     struct xkb xkb;
 
     xkb_keysym_t sym;

--- a/lib/renderers/x11/x11.c
+++ b/lib/renderers/x11/x11.c
@@ -7,7 +7,7 @@
 #include <X11/Xutil.h>
 
 static void
-render(const struct bm_menu *menu)
+render(struct bm_menu *menu)
 {
     struct x11 *x11 = menu->renderer->internal;
 


### PR DESCRIPTION
resolve: https://github.com/Cloudef/bemenu/issues/199

My main goal is to offer [Sxmo](https://sr.ht/~mil/sxmo/) a way to Wayland. We rely mainly on dmenu so we have to improve bemenu which is the best solution at this time.

To allow convergent usage (desktop + mobiles) I made those choices of inputs : 

```
For bar mode:    

    In pointer mode (mouse):

    - Mouse wheel select the next/previous entry
    - Click return the entry

For line mode:

    In pointer mode (mouse):

    - Moving the mouse over entries highlight them
    - Click return the entry
    - Mouse wheel scroll pages

    In touch mode (mobile);

    - Touch and move over entries highlight them
    - Release touch on an entry return this entry
    - Release touch outside of bemenu cancel the selection (left or right of bemenu)
    - Release touch above or bellow bemenu scroll the page previous or next
    - You can also double touch and scroll up or down to scroll the pages
```

One question remains to me: 

- Is the redraw could be optimized ? With this patch, I removed the `last_code` toggle cause we now have pointer events. I could not find a way to not redraw the window if my cursor moved from 5 px in the exact same entry but I think we should !

This is a big patch and I made decisive choices. I open to ideas and improvement !

This need Sway to support touch seat operation to works correctly with touches: 

https://github.com/swaywm/sway/pull/6455

To demonstrate the touch support, I recorded this for Sxmo : 

https://tube.missbanal.net/videos/watch/7a7c1bbe-ac19-4593-9e56-e46c82cbb20c
