### PR TITLE
Add option to configure cursor height

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -197,6 +197,7 @@ usage(FILE *out, const char *name)
           " -n, --no-overlap      adjust geometry to not overlap with panels. (w)\n"
           " -m, --monitor         index of monitor where menu will appear. (wx)\n"
           " -H, --line-height     defines the height to make each menu line (0 = default height). (wx)\n"
+          " --ch                  defines the height of the cursor (0 = scales with line height). (wx)\n"
           " --fn                  defines the font to be used ('name [size]'). (wx)\n"
           " --tb                  defines the title background color. (wx)\n"
           " --tf                  defines the title foreground color. (wx)\n"
@@ -260,6 +261,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
         { "no-overlap",  no_argument,       0, 'n' },
         { "monitor",     required_argument, 0, 'm' },
         { "line-height", required_argument, 0, 'H' },
+        { "ch",          required_argument, 0, 0x118 },
         { "fn",          required_argument, 0, 0x101 },
         { "tb",          required_argument, 0, 0x102 },
         { "tf",          required_argument, 0, 0x103 },
@@ -355,6 +357,9 @@ do_getopt(struct client *client, int *argc, char **argv[])
             case 'H':
                 client->line_height = strtol(optarg, NULL, 10);
                 break;
+            case 0x118:
+                client->cursor_height = strtol(optarg, NULL, 10);
+                break;
             case 0x101:
                 client->font = optarg;
                 break;
@@ -433,6 +438,7 @@ menu_with_options(struct client *client)
 
     bm_menu_set_font(menu, client->font);
     bm_menu_set_line_height(menu, client->line_height);
+    bm_menu_set_cursor_height(menu, client->cursor_height);
     bm_menu_set_title(menu, client->title);
     bm_menu_set_prefix(menu, client->prefix);
     bm_menu_set_filter_mode(menu, client->filter_mode);

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -13,6 +13,7 @@ struct client {
     const char *font;
     const char *initial_filter;
     uint32_t line_height;
+    uint32_t cursor_height;
     uint32_t lines;
     uint32_t selected;
     uint32_t monitor;

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -449,6 +449,23 @@ BM_PUBLIC void bm_menu_set_line_height(struct bm_menu *menu, uint32_t line_heigh
 BM_PUBLIC uint32_t bm_menu_get_line_height(struct bm_menu *menu);
 
 /**
+ * Set height of cursor in pixels.
+ * Some renderers such as ncurses may ignore this when it does not make sense.
+ *
+ * @param menu bm_menu instance where to set cursor height.
+ * @param cursor_height 0 for default cursor height, > 0 for that many pixels.
+ */
+BM_PUBLIC void bm_menu_set_cursor_height(struct bm_menu *menu, uint32_t cursor_height);
+
+/**
+ * Get height of cursor in pixels.
+ *
+ * @param menu bm_menu instance where to get cursor height.
+ * @return uint32_t for max amount of vertical cursors to be shown.
+ */
+BM_PUBLIC uint32_t bm_menu_get_cursor_height(struct bm_menu *menu);
+
+/**
  * Set a hexadecimal color for element.
  *
  * @param menu bm_menu instance where to set color.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -239,6 +239,11 @@ struct bm_menu {
     uint32_t line_height;
 
     /**
+     * Cursor height.
+     */
+    uint32_t cursor_height;
+
+    /**
      * Colors.
      */
     struct bm_hex_color colors[BM_COLOR_LAST];

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -296,6 +296,20 @@ bm_menu_get_line_height(struct bm_menu *menu)
     return menu->line_height;
 }
 
+void
+bm_menu_set_cursor_height(struct bm_menu *menu, uint32_t cursor_height)
+{
+    assert(menu);
+    menu->cursor_height = cursor_height;
+}
+
+uint32_t
+bm_menu_get_cursor_height(struct bm_menu *menu)
+{
+    assert(menu);
+    return menu->cursor_height;
+}
+
 bool
 bm_menu_set_color(struct bm_menu *menu, enum bm_color color, const char *hex)
 {


### PR DESCRIPTION
If set to 0 (the default), the height of the cursor is set to the
height of the line (as is the current behaviour).