### PR TITLE
Add -s to disable title spacing on entries

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -175,6 +175,7 @@ usage(FILE *out, const char *name)
           " -P, --prefix          text to show before highlighted item.\n"
           " -I, --index           select item at index automatically.\n"
           " -x, --password        hide input.\n"
+          " -s, --no-spacing      disable the title spacing on entries.\n"
           " --scrollbar           display scrollbar. (none (default), always, autohide)\n"
           " --ifne                only display menu if there are items.\n"
           " --fork                always fork. (bemenu-run)\n"
@@ -259,6 +260,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
         { "bottom",      no_argument,       0, 'b' },
         { "grab",        no_argument,       0, 'f' },
         { "no-overlap",  no_argument,       0, 'n' },
+        { "no-spacing",  no_argument,       0, 's' },
         { "monitor",     required_argument, 0, 'm' },
         { "line-height", required_argument, 0, 'H' },
         { "ch",          required_argument, 0, 0x118 },
@@ -290,7 +292,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
     for (optind = 0;;) {
         int32_t opt;
 
-        if ((opt = getopt_long(*argc, *argv, "hviwxcl:I:p:P:I:bfm:H:n", opts, NULL)) < 0)
+        if ((opt = getopt_long(*argc, *argv, "hviwxcl:I:p:P:I:bfm:H:ns", opts, NULL)) < 0)
             break;
 
         switch (opt) {
@@ -352,6 +354,9 @@ do_getopt(struct client *client, int *argc, char **argv[])
                 break;
             case 'n':
                 client->no_overlap = true;
+                break;
+            case 's':
+                client->no_spacing = true;
                 break;
 
             case 'H':
@@ -448,6 +453,7 @@ menu_with_options(struct client *client)
     bm_menu_set_monitor_name(menu, client->monitor_name);
     bm_menu_set_scrollbar(menu, client->scrollbar);
     bm_menu_set_panel_overlap(menu, !client->no_overlap);
+    bm_menu_set_spacing(menu, !client->no_spacing);
     bm_menu_set_password(menu, client->password);
 
     if (client->center) {

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -23,6 +23,7 @@ struct client {
     bool wrap;
     bool ifne;
     bool no_overlap;
+    bool no_spacing;
     bool force_fork, fork;
     bool no_exec;
     bool password;

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -584,6 +584,14 @@ BM_PUBLIC void bm_menu_set_panel_overlap(struct bm_menu *menu, bool overlap);
 BM_PUBLIC void bm_menu_set_password(struct bm_menu *menu, bool password);
 
 /**
+ * Space entries with title.
+ *
+ * @param menu bm_menu instance to set password mode for.
+ * @param spacing true to enable title spacing
+ */
+BM_PUBLIC void bm_menu_set_spacing(struct bm_menu *menu, bool spacing);
+
+/**
  * Is password mode activated and input hidden?
  *
  * @param menu bm_menu instance where to get password mode from.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -345,6 +345,11 @@ struct bm_menu {
      * Should the input be hidden
      */
     bool password;
+
+    /**
+     * Should the entry should follow the title spacing
+     */
+    bool spacing;
 };
 
 /* library.c */

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -462,6 +462,17 @@ bm_menu_set_panel_overlap(struct bm_menu *menu, bool overlap)
 }
 
 void
+bm_menu_set_spacing(struct bm_menu *menu, bool spacing)
+{
+    assert(menu);
+
+    if (menu->spacing == spacing)
+        return;
+
+    menu->spacing = spacing;
+}
+
+void
 bm_menu_set_password(struct bm_menu *menu, bool password)
 {
     assert(menu);

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -277,7 +277,7 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
         /* vertical mode */
 
         const bool scrollbar = (menu->scrollbar > BM_SCROLLBAR_NONE && (menu->scrollbar != BM_SCROLLBAR_AUTOHIDE || count > lines) ? true : false);
-        uint32_t spacing_x = title_x, spacing_y = 0; // 0 == variable width spacing
+        uint32_t spacing_x = menu->spacing ? title_x : 0, spacing_y = 0; // 0 == variable width spacing
         if (lines > max_height / titleh) {
             /* there is more lines than screen can fit, enter fixed spacing mode */
             lines = max_height / titleh - 1;
@@ -294,7 +294,7 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
         if (scrollbar) {
             bm_pango_get_text_extents(cairo, &paint, &result, "#");
             scrollbar_w = result.x_advance;
-            spacing_x += (title_x < scrollbar_w ? scrollbar_w - title_x : 0);
+            spacing_x += (spacing_x < scrollbar_w ? scrollbar_w : 0);
         }
 
         uint32_t posy = titleh;


### PR DESCRIPTION
Way better on mobile screen size.

also related to: https://github.com/Cloudef/bemenu/issues/194