### PR TITLE
Fix incorrect line height 

### DIFF
--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -237,15 +237,16 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
     ascii_height = result.height;
     paint.baseline = result.baseline;
 
-    int32_t vpadding = height == 0 ? 2 : (height - ascii_height) / 2;
+    int32_t vpadding_t = height == 0 ? 2 : (height - ascii_height) / 2;
+	int32_t vpadding_b = vpadding_t + (height - ascii_height) % 2;
 
     memset(&result, 0, sizeof(result));
     uint32_t title_x = 0;
     if (menu->title) {
         bm_cairo_color_from_menu_color(menu, BM_COLOR_TITLE_FG, &paint.fg);
         bm_cairo_color_from_menu_color(menu, BM_COLOR_TITLE_BG, &paint.bg);
-        paint.pos = (struct pos){ result.x_advance, vpadding };
-        paint.box = (struct box){ 4, 8, vpadding, vpadding, 0, ascii_height };
+        paint.pos = (struct pos){ result.x_advance, vpadding_t };
+        paint.box = (struct box){ 4, 8, vpadding_t, vpadding_b, 0, ascii_height };
         bm_cairo_draw_line(cairo, &paint, &result, "%s", menu->title);
         title_x = result.x_advance;
     }
@@ -255,8 +256,8 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
     paint.draw_cursor = true;
     paint.cursor = menu->cursor;
     paint.cursor_height = menu->cursor_height;
-    paint.pos = (struct pos){ (menu->title ? 2 : 0) + result.x_advance, vpadding };
-    paint.box = (struct box){ (menu->title ? 2 : 4), 0, vpadding, vpadding, width - paint.pos.x, ascii_height };
+    paint.pos = (struct pos){ (menu->title ? 2 : 0) + result.x_advance, vpadding_t };
+    paint.box = (struct box){ (menu->title ? 2 : 4), 0, vpadding_t, vpadding_b, width - paint.pos.x, ascii_height };
 
     const char *filter_text = (menu->filter ? menu->filter : "");
     if (menu->password) {
@@ -314,12 +315,12 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
             }
 
             if (menu->prefix && highlighted) {
-                paint.pos = (struct pos){ spacing_x, vpadding + posy };
-                paint.box = (struct box){ 4, 0, vpadding, vpadding, width - paint.pos.x, ascii_height };
+                paint.pos = (struct pos){ spacing_x, vpadding_t + posy };
+                paint.box = (struct box){ 4, 0, vpadding_t, vpadding_b, width - paint.pos.x, ascii_height };
                 bm_cairo_draw_line(cairo, &paint, &result, "%s %s", menu->prefix, (items[i]->text ? items[i]->text : ""));
             } else {
-                paint.pos = (struct pos){ spacing_x, vpadding + posy };
-                paint.box = (struct box){ 4 + prefix_x, 0, vpadding, vpadding, width - paint.pos.x, ascii_height };
+                paint.pos = (struct pos){ spacing_x, vpadding_t + posy };
+                paint.box = (struct box){ 4 + prefix_x, 0, vpadding_t, vpadding_b, width - paint.pos.x, ascii_height };
                 bm_cairo_draw_line(cairo, &paint, &result, "%s", (items[i]->text ? items[i]->text : ""));
             }
 
@@ -358,8 +359,8 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
         uint32_t cl = fmin(title_x + result.x_advance, width / 4);
 
         if (count > 0) {
-            paint.pos = (struct pos){ cl, vpadding };
-            paint.box = (struct box){ 1, 2, vpadding, vpadding, 0, ascii_height };
+            paint.pos = (struct pos){ cl, vpadding_t };
+            paint.box = (struct box){ 1, 2, vpadding_t, vpadding_b, 0, ascii_height };
             bm_cairo_draw_line(cairo, &paint, &result, (count > 0 && (menu->wrap || menu->index > 0) ? "<" : " "));
             cl += result.x_advance + 1;
         }
@@ -378,8 +379,8 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
                 bm_cairo_color_from_menu_color(menu, BM_COLOR_ITEM_BG, &paint.bg);
             }
 
-            paint.pos = (struct pos){ cl, vpadding };
-            paint.box = (struct box){ 2, 4, vpadding, vpadding, 0, ascii_height };
+            paint.pos = (struct pos){ cl, vpadding_t };
+            paint.box = (struct box){ 2, 4, vpadding_t, vpadding_b, 0, ascii_height };
             bm_cairo_draw_line(cairo, &paint, &result, "%s", (items[i]->text ? items[i]->text : ""));
             cl += result.x_advance + 2;
             out_result->displayed += (cl < width);
@@ -390,8 +391,8 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
             bm_cairo_color_from_menu_color(menu, BM_COLOR_FILTER_FG, &paint.fg);
             bm_cairo_color_from_menu_color(menu, BM_COLOR_FILTER_BG, &paint.bg);
             bm_pango_get_text_extents(cairo, &paint, &result, ">");
-            paint.pos = (struct pos){ width/cairo->scale - result.x_advance - 2, vpadding };
-            paint.box = (struct box){ 1, 2, vpadding, vpadding, 0, ascii_height };
+            paint.pos = (struct pos){ width/cairo->scale - result.x_advance - 2, vpadding_t };
+            paint.box = (struct box){ 1, 2, vpadding_t, vpadding_b, 0, ascii_height };
             bm_cairo_draw_line(cairo, &paint, &result, ">");
         }
     }

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -238,7 +238,7 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
     paint.baseline = result.baseline;
 
     int32_t vpadding_t = height == 0 ? 2 : (height - ascii_height) / 2;
-	int32_t vpadding_b = vpadding_t + (height - ascii_height) % 2;
+    int32_t vpadding_b = vpadding_t + (height - ascii_height) % 2;
 
     memset(&result, 0, sizeof(result));
     uint32_t title_x = 0;


### PR DESCRIPTION
Hi, I found a fix for the [incorrect line height rendering issue](https://github.com/Cloudef/bemenu/issues/128).

It seems that `vpadding` for the text is calculated with a integer division by 2, with the same padding applied above and below the text, which effectively quantizes the overall height to odd numbers. The solution I used was to calculate a separate `vpadding` for the top and bottom of the text, so when an even number is given for the line height, `vpadding_t = vpadding_b+1`. Now testing across `--line-height=23`, `--line-height=24` and `--line-height=28` all result in the correct line height being rendered.

I'm not really that familiar with cairo or the rest of the project so pls forgive me if the fix seems hacky or if there is a better solution.