### PR TITLE
Add horizontal alignment and improve center alignment

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -266,7 +266,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
         { "no-spacing",  no_argument,       0, 's' },
         { "monitor",     required_argument, 0, 'm' },
         { "line-height", required_argument, 0, 'H' },
-	{ "margin",      required_argument, 0, 'M' },
+        { "margin",      required_argument, 0, 'M' },
         { "ch",          required_argument, 0, 0x118 },
         { "fn",          required_argument, 0, 0x101 },
         { "tb",          required_argument, 0, 0x102 },

--- a/client/common/common.c
+++ b/client/common/common.c
@@ -198,6 +198,7 @@ usage(FILE *out, const char *name)
           " -n, --no-overlap      adjust geometry to not overlap with panels. (w)\n"
           " -m, --monitor         index of monitor where menu will appear. (wx)\n"
           " -H, --line-height     defines the height to make each menu line (0 = default height). (wx)\n"
+          " -M, --margin          defines the empty space on either side of the menu. (wx)"
           " --ch                  defines the height of the cursor (0 = scales with line height). (wx)\n"
           " --fn                  defines the font to be used ('name [size]'). (wx)\n"
           " --tb                  defines the title background color. (wx)\n"
@@ -263,6 +264,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
         { "no-spacing",  no_argument,       0, 's' },
         { "monitor",     required_argument, 0, 'm' },
         { "line-height", required_argument, 0, 'H' },
+	{ "margin",      required_argument, 0, 'M' },
         { "ch",          required_argument, 0, 0x118 },
         { "fn",          required_argument, 0, 0x101 },
         { "tb",          required_argument, 0, 0x102 },
@@ -292,7 +294,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
     for (optind = 0;;) {
         int32_t opt;
 
-        if ((opt = getopt_long(*argc, *argv, "hviwxcl:I:p:P:I:bfm:H:ns", opts, NULL)) < 0)
+        if ((opt = getopt_long(*argc, *argv, "hviwxcl:I:p:P:I:bfm:H:M:ns", opts, NULL)) < 0)
             break;
 
         switch (opt) {
@@ -361,6 +363,9 @@ do_getopt(struct client *client, int *argc, char **argv[])
 
             case 'H':
                 client->line_height = strtol(optarg, NULL, 10);
+                break;
+            case 'M':
+                client->hmargin_size = strtol(optarg, NULL, 10);
                 break;
             case 0x118:
                 client->cursor_height = strtol(optarg, NULL, 10);
@@ -455,6 +460,7 @@ menu_with_options(struct client *client)
     bm_menu_set_panel_overlap(menu, !client->no_overlap);
     bm_menu_set_spacing(menu, !client->no_spacing);
     bm_menu_set_password(menu, client->password);
+    bm_menu_set_hmargin_size(menu, client->hmargin_size);
 
     if (client->center) {
         bm_menu_set_center(menu, client->center);

--- a/client/common/common.c
+++ b/client/common/common.c
@@ -1,3 +1,5 @@
+#include "internal.h"
+
 #include "common.h"
 #include <stdlib.h>
 #include <string.h>
@@ -193,7 +195,7 @@ usage(FILE *out, const char *name)
           "   (...) At end of help indicates the backend support for option.\n\n"
 
           " -b, --bottom          appears at the bottom of the screen. (wx)\n"
-          " -c, --center          appears at the center of the screen. (w)\n"
+          " -c, --center          appears at the center of the screen. (wx)\n"
           " -f, --grab            show the menu before reading stdin. (wx)\n"
           " -n, --no-overlap      adjust geometry to not overlap with panels. (w)\n"
           " -m, --monitor         index of monitor where menu will appear. (wx)\n"
@@ -463,9 +465,11 @@ menu_with_options(struct client *client)
     bm_menu_set_hmargin_size(menu, client->hmargin_size);
 
     if (client->center) {
-        bm_menu_set_center(menu, client->center);
+        bm_menu_set_align(menu, BM_ALIGN_CENTER);
     } else if (client->bottom) {
-        bm_menu_set_bottom(menu, client->bottom);
+        bm_menu_set_align(menu, BM_ALIGN_BOTTOM);
+    } else {
+        bm_menu_set_align(menu, BM_ALIGN_TOP);
     }
 
     for (uint32_t i = 0; i < BM_COLOR_LAST; ++i)

--- a/client/common/common.c
+++ b/client/common/common.c
@@ -200,7 +200,7 @@ usage(FILE *out, const char *name)
           " -n, --no-overlap      adjust geometry to not overlap with panels. (w)\n"
           " -m, --monitor         index of monitor where menu will appear. (wx)\n"
           " -H, --line-height     defines the height to make each menu line (0 = default height). (wx)\n"
-          " -M, --margin          defines the empty space on either side of the menu. (wx)"
+          " -M, --margin          defines the empty space on either side of the menu. (wx)\n"
           " --ch                  defines the height of the cursor (0 = scales with line height). (wx)\n"
           " --fn                  defines the font to be used ('name [size]'). (wx)\n"
           " --tb                  defines the title background color. (wx)\n"

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -17,6 +17,7 @@ struct client {
     uint32_t lines;
     uint32_t selected;
     uint32_t monitor;
+    uint32_t hmargin_size;
     bool bottom;
     bool center;
     bool grab;

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -116,6 +116,26 @@ enum bm_priorty {
 };
 
 /**
+ * Vertical position of the menu.
+ */
+enum bm_align {
+    /**
+     * Menu is at the top of the screen.
+     */
+    BM_ALIGN_TOP,
+
+    /**
+     * Menu is at the bottom of the screen.
+     */
+    BM_ALIGN_BOTTOM,
+
+    /**
+     * Menu is in the center of the screen.
+     */
+    BM_ALIGN_CENTER,
+};
+
+/**
  * Get name of the renderer.
  *
  * @param renderer bm_renderer instance.
@@ -501,30 +521,21 @@ BM_PUBLIC void bm_menu_set_scrollbar(struct bm_menu *menu, enum bm_scrollbar_mod
 BM_PUBLIC enum bm_scrollbar_mode bm_menu_get_scrollbar(struct bm_menu *menu);
 
 /**
- * Display menu at center of the screen.
- * This may be no-op on some renderers (curses, wayland)
+ * Set the vertical alignment of the bar.
  *
- * @param menu bm_menu instance to set center mode for.
- * @param center true for center mode, false for top mode.
+ * @param menu bm_menu to set alignment for.
+ * @param align alignment to set
  */
-BM_PUBLIC void bm_menu_set_center(struct bm_menu *menu, bool center);
+BM_PUBLIC void bm_menu_set_align(struct bm_menu *menu, enum bm_align align);
 
 /**
- * Display menu at bottom of the screen.
- * This may be no-op on some renderers (curses, wayland)
+ * Get the vertical alignment of the bar.
  *
- * @param menu bm_menu instance to set bottom mode for.
- * @param bottom true for bottom mode, false for top mode.
+ * @param menu bm_menu to get alignment for.
+ * @return alignment for the menu
  */
-BM_PUBLIC void bm_menu_set_bottom(struct bm_menu *menu, bool bottom);
 
-/**
- * Is menu being displayed at bottom of the screen?
- *
- * @param menu bm_menu instance where to get bottom mode from.
- * @return true if bottom mode, false otherwise.
- */
-BM_PUBLIC bool bm_menu_get_bottom(struct bm_menu *menu);
+BM_PUBLIC enum bm_align bm_menu_get_align(struct bm_menu *menu);
 
 /**
  * Set the horizontal margin of the bar.

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -527,6 +527,24 @@ BM_PUBLIC void bm_menu_set_bottom(struct bm_menu *menu, bool bottom);
 BM_PUBLIC bool bm_menu_get_bottom(struct bm_menu *menu);
 
 /**
+ * Set the horizontal margin of the bar.
+ *
+ * @param menu bm_menu to set horizontal margin for.
+ * @param margin margin to set.
+ */
+
+BM_PUBLIC void bm_menu_set_hmargin_size(struct bm_menu *menu, uint32_t margin);
+
+/**
+ * Get the horizontal margin of the bar.
+ *
+ * @param menu bm_menu to get horizontal margin from.
+ * @return horizontal margin of the menu
+ */
+
+BM_PUBLIC uint32_t bm_menu_get_hmargin_size(struct bm_menu *menu);
+
+/**
  * Display menu at monitor index.
  * Indices start at 0, a value of -1 can be passed for the active monitor (default).
  * If index is more than amount of monitors, the monitor with highest index will be selected.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -78,19 +78,14 @@ struct render_api {
     void (*render)(const struct bm_menu *menu);
 
     /**
-     * Set menu to appear from bottom of the screen.
+     * Set vertical alignment of the bar.
      */
-    void (*set_bottom)(const struct bm_menu *menu, bool bottom);
+    void (*set_align)(const struct bm_menu *menu, enum bm_align align);
 
     /**
      * Set horizontal margin.
      */
     void (*set_hmargin_size)(const struct bm_menu *menu, uint32_t margin);
-
-    /**
-     * Set menu to appear from center of the screen.
-     */
-    void (*set_center)(const struct bm_menu *menu, bool center);
 
     /**
      * Set monitor indeax where menu will appear
@@ -330,14 +325,9 @@ struct bm_menu {
     bool wrap;
 
     /**
-     * Is menu shown from center?
+     * Vertical alignment.
      */
-    bool center;
-
-    /**
-     * Is menu shown from bottom?
-     */
-    bool bottom;
+    enum bm_align align;
 
     /**
      * Horizontal margin.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -18,6 +18,9 @@ extern char *secure_getenv(const char *name);
 #include <stddef.h> /* for size_t */
 #include <stdarg.h>
 
+//minimum allowed window width when setting margin
+#define WINDOW_MIN_WIDTH 80
+
 /**
  * Destructor function pointer for some list calls.
  */
@@ -78,6 +81,11 @@ struct render_api {
      * Set menu to appear from bottom of the screen.
      */
     void (*set_bottom)(const struct bm_menu *menu, bool bottom);
+
+    /**
+     * Set horizontal margin.
+     */
+    void (*set_hmargin_size)(const struct bm_menu *menu, uint32_t margin);
 
     /**
      * Set menu to appear from center of the screen.
@@ -330,6 +338,11 @@ struct bm_menu {
      * Is menu shown from bottom?
      */
     bool bottom;
+
+    /**
+     * Horizontal margin.
+     */
+    uint32_t hmargin_size;
 
     /**
      * Is menu grabbed?

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -357,12 +357,12 @@ bm_menu_get_scrollbar(struct bm_menu *menu)
 void
 bm_menu_set_align(struct bm_menu *menu, enum bm_align align)
 {
-	assert(menu);
+    assert(menu);
 
-	if(menu->align == align)
-	    return;
+    if(menu->align == align)
+        return;
 
-	menu->align = align;
+    menu->align = align;
 
     if (menu->renderer->api.set_align)
         menu->renderer->api.set_align(menu, align);
@@ -371,22 +371,22 @@ bm_menu_set_align(struct bm_menu *menu, enum bm_align align)
 enum bm_align
 bm_menu_get_align(struct bm_menu *menu)
 {
-	assert(menu);
-	return menu->align;
+    assert(menu);
+    return menu->align;
 }
 
 void
 bm_menu_set_hmargin_size(struct bm_menu *menu, uint32_t margin)
 {
-	assert(menu);
+    assert(menu);
 
-	if(menu->hmargin_size == margin)
-	    return;
+    if(menu->hmargin_size == margin)
+        return;
 
-	menu->hmargin_size = margin;
+    menu->hmargin_size = margin;
 
-	if(menu->renderer->api.set_hmargin_size)
-		menu->renderer->api.set_hmargin_size(menu, margin);
+    if(menu->renderer->api.set_hmargin_size)
+        menu->renderer->api.set_hmargin_size(menu, margin);
 }
 
 uint32_t

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -390,6 +390,27 @@ bm_menu_get_bottom(struct bm_menu *menu)
 }
 
 void
+bm_menu_set_hmargin_size(struct bm_menu *menu, uint32_t margin)
+{
+	assert(menu);
+
+	if(menu->hmargin_size == margin)
+	    return;
+
+	menu->hmargin_size = margin;
+
+	if(menu->renderer->api.set_hmargin_size)
+		menu->renderer->api.set_hmargin_size(menu, margin);
+}
+
+uint32_t
+bm_menu_get_hmargin_size(struct bm_menu *menu)
+{
+    assert(menu);
+    return menu->hmargin_size;
+}
+
+void
 bm_menu_set_monitor(struct bm_menu *menu, int32_t monitor)
 {
     assert(menu);

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -355,38 +355,24 @@ bm_menu_get_scrollbar(struct bm_menu *menu)
 }
 
 void
-bm_menu_set_center(struct bm_menu *menu, bool center)
+bm_menu_set_align(struct bm_menu *menu, enum bm_align align)
 {
-    assert(menu);
+	assert(menu);
 
-    if (menu->center == center)
-        return;
+	if(menu->align == align)
+	    return;
 
-    menu->center = center;
+	menu->align = align;
 
-    if (menu->renderer->api.set_center)
-        menu->renderer->api.set_center(menu, center);
+    if (menu->renderer->api.set_align)
+        menu->renderer->api.set_align(menu, align);
 }
 
-void
-bm_menu_set_bottom(struct bm_menu *menu, bool bottom)
+enum bm_align
+bm_menu_get_align(struct bm_menu *menu)
 {
-    assert(menu);
-
-    if (menu->bottom == bottom)
-        return;
-
-    menu->bottom = bottom;
-
-    if (menu->renderer->api.set_bottom)
-        menu->renderer->api.set_bottom(menu, bottom);
-}
-
-bool
-bm_menu_get_bottom(struct bm_menu *menu)
-{
-    assert(menu);
-    return menu->bottom;
+	assert(menu);
+	return menu->align;
 }
 
 void

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -236,7 +236,7 @@ set_hmargin_size(const struct bm_menu *menu, uint32_t margin)
 
     struct window *window;
     wl_list_for_each(window, &wayland->windows, link) {
-	bm_wl_window_set_hmargin_size(window, wayland->display, margin);
+        bm_wl_window_set_hmargin_size(window, wayland->display, margin);
     }
 }
 
@@ -317,7 +317,7 @@ recreate_windows(const struct bm_menu *menu, struct wayland *wayland)
         wl_surface_set_buffer_scale(surface, output->scale);
 
         struct window *window = calloc(1, sizeof(struct window));
-	window->align = menu->align;
+        window->align = menu->align;
         window->hmargin_size = menu->hmargin_size;
 
         const char *scale = getenv("BEMENU_SCALE");

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -229,18 +229,6 @@ get_displayed_count(const struct bm_menu *menu)
 }
 
 static void
-set_bottom(const struct bm_menu *menu, bool bottom)
-{
-    struct wayland *wayland = menu->renderer->internal;
-    assert(wayland);
-
-    struct window *window;
-    wl_list_for_each(window, &wayland->windows, link) {
-        bm_wl_window_set_bottom(window, wayland->display, bottom);
-    }
-}
-
-static void
 set_hmargin_size(const struct bm_menu *menu, uint32_t margin)
 {
     struct wayland *wayland = menu->renderer->internal;
@@ -253,14 +241,14 @@ set_hmargin_size(const struct bm_menu *menu, uint32_t margin)
 }
 
 static void
-set_center(const struct bm_menu *menu, bool center)
+set_align(const struct bm_menu *menu, enum bm_align align)
 {
     struct wayland *wayland = menu->renderer->internal;
     assert(wayland);
 
     struct window *window;
     wl_list_for_each(window, &wayland->windows, link) {
-        bm_wl_window_set_center(window, wayland->display, center);
+        bm_wl_window_set_align(window, wayland->display, align);
     }
 }
 
@@ -329,7 +317,7 @@ recreate_windows(const struct bm_menu *menu, struct wayland *wayland)
         wl_surface_set_buffer_scale(surface, output->scale);
 
         struct window *window = calloc(1, sizeof(struct window));
-        window->bottom = menu->bottom;
+	window->align = menu->align;
         window->hmargin_size = menu->hmargin_size;
 
         const char *scale = getenv("BEMENU_SCALE");
@@ -457,8 +445,7 @@ register_renderer(struct render_api *api)
     api->get_displayed_count = get_displayed_count;
     api->poll_key = poll_key;
     api->render = render;
-    api->set_center = set_center;
-    api->set_bottom = set_bottom;
+    api->set_align = set_align;
     api->set_hmargin_size = set_hmargin_size;
     api->grab_keyboard = grab_keyboard;
     api->set_overlap = set_overlap;

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -241,6 +241,18 @@ set_bottom(const struct bm_menu *menu, bool bottom)
 }
 
 static void
+set_hmargin_size(const struct bm_menu *menu, uint32_t margin)
+{
+    struct wayland *wayland = menu->renderer->internal;
+    assert(wayland);
+
+    struct window *window;
+    wl_list_for_each(window, &wayland->windows, link) {
+	bm_wl_window_set_hmargin_size(window, wayland->display, margin);
+    }
+}
+
+static void
 set_center(const struct bm_menu *menu, bool center)
 {
     struct wayland *wayland = menu->renderer->internal;
@@ -318,6 +330,7 @@ recreate_windows(const struct bm_menu *menu, struct wayland *wayland)
 
         struct window *window = calloc(1, sizeof(struct window));
         window->bottom = menu->bottom;
+        window->hmargin_size = menu->hmargin_size;
 
         const char *scale = getenv("BEMENU_SCALE");
         if (scale) {
@@ -446,6 +459,7 @@ register_renderer(struct render_api *api)
     api->render = render;
     api->set_center = set_center;
     api->set_bottom = set_bottom;
+    api->set_hmargin_size = set_hmargin_size;
     api->grab_keyboard = grab_keyboard;
     api->set_overlap = set_overlap;
     api->set_monitor = set_monitor;

--- a/lib/renderers/wayland/wayland.h
+++ b/lib/renderers/wayland/wayland.h
@@ -1,6 +1,8 @@
 #ifndef _BM_WAYLAND_H_
 #define _BM_WAYLAND_H_
 
+#include "internal.h"
+
 #include <wayland-client.h>
 #include <xkbcommon/xkbcommon.h>
 
@@ -88,8 +90,8 @@ struct window {
     int32_t scale;
     uint32_t displayed;
     struct wl_list link;
-    bool bottom;
-    bool center;
+    enum bm_align align;
+    uint32_t align_anchor;
     bool render_pending;
 
     struct {
@@ -130,9 +132,8 @@ bool bm_wl_registry_register(struct wayland *wayland);
 void bm_wl_registry_destroy(struct wayland *wayland);
 void bm_wl_window_schedule_render(struct window *window);
 void bm_wl_window_render(struct window *window, struct wl_display *display, const struct bm_menu *menu);
-void bm_wl_window_set_bottom(struct window *window, struct wl_display *display, bool bottom);
 void bm_wl_window_set_hmargin_size(struct window *window, struct wl_display *display, uint32_t margin);
-void bm_wl_window_set_center(struct window *window, struct wl_display *display, bool center);
+void bm_wl_window_set_align(struct window *window, struct wl_display *display, enum bm_align align);
 void bm_wl_window_grab_keyboard(struct window *window, struct wl_display *display, bool grab);
 void bm_wl_window_set_overlap(struct window *window, struct wl_display *display, bool overlap);
 bool bm_wl_window_create(struct window *window, struct wl_display *display, struct wl_shm *shm, struct wl_output *output, struct zwlr_layer_shell_v1 *layer_shell, struct wl_surface *surface);

--- a/lib/renderers/wayland/wayland.h
+++ b/lib/renderers/wayland/wayland.h
@@ -84,6 +84,7 @@ struct window {
     struct wl_shm *shm;
     struct buffer buffers[2];
     uint32_t width, height, max_height;
+    uint32_t hmargin_size;
     int32_t scale;
     uint32_t displayed;
     struct wl_list link;
@@ -130,6 +131,7 @@ void bm_wl_registry_destroy(struct wayland *wayland);
 void bm_wl_window_schedule_render(struct window *window);
 void bm_wl_window_render(struct window *window, struct wl_display *display, const struct bm_menu *menu);
 void bm_wl_window_set_bottom(struct window *window, struct wl_display *display, bool bottom);
+void bm_wl_window_set_hmargin_size(struct window *window, struct wl_display *display, uint32_t margin);
 void bm_wl_window_set_center(struct window *window, struct wl_display *display, bool center);
 void bm_wl_window_grab_keyboard(struct window *window, struct wl_display *display, bool grab);
 void bm_wl_window_set_overlap(struct window *window, struct wl_display *display, bool overlap);

--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -308,7 +308,7 @@ get_window_width(struct window *window)
     uint32_t width = window->width - 2 * window->hmargin_size;
 
     if(width < WINDOW_MIN_WIDTH || 2 * window->hmargin_size > window->width)
-	width = WINDOW_MIN_WIDTH;
+        width = WINDOW_MIN_WIDTH;
 
     return width;
 }
@@ -321,23 +321,23 @@ static const struct zwlr_layer_surface_v1_listener layer_surface_listener = {
 void
 bm_wl_window_set_hmargin_size(struct window *window, struct wl_display *display, uint32_t margin)
 {
-	if(window->hmargin_size == margin)
-	    return;
+    if(window->hmargin_size == margin)
+        return;
 
-	window->hmargin_size = margin;
+    window->hmargin_size = margin;
 
-        zwlr_layer_surface_v1_set_anchor(window->layer_surface, window->align_anchor);
-	zwlr_layer_surface_v1_set_size(window->layer_surface, get_window_width(window), window->height);
+    zwlr_layer_surface_v1_set_anchor(window->layer_surface, window->align_anchor);
+    zwlr_layer_surface_v1_set_size(window->layer_surface, get_window_width(window), window->height);
 
-        wl_surface_commit(window->surface);
-        wl_display_roundtrip(display);
+    wl_surface_commit(window->surface);
+    wl_display_roundtrip(display);
 }
 
 void
 bm_wl_window_set_align(struct window *window, struct wl_display *display, enum bm_align align)
 {
     if(window->align == align)
-	return;
+        return;
 
     window->align = align;
 
@@ -371,14 +371,14 @@ bm_wl_window_create(struct window *window, struct wl_display *display, struct wl
 
     if (layer_shell && (window->layer_surface = zwlr_layer_shell_v1_get_layer_surface(layer_shell, surface, output, ZWLR_LAYER_SHELL_V1_LAYER_TOP, "menu"))) {
         zwlr_layer_surface_v1_add_listener(window->layer_surface, &layer_surface_listener, window);
-	window->align_anchor = get_align_anchor(window->align);
+        window->align_anchor = get_align_anchor(window->align);
         zwlr_layer_surface_v1_set_anchor(window->layer_surface, window->align_anchor);
         zwlr_layer_surface_v1_set_size(window->layer_surface, 0, 32);
 
         wl_surface_commit(surface);
         wl_display_roundtrip(display);
 
-	zwlr_layer_surface_v1_set_size(window->layer_surface, get_window_width(window), 32);
+        zwlr_layer_surface_v1_set_size(window->layer_surface, get_window_width(window), 32);
     } else {
         return false;
     }

--- a/lib/renderers/x11/window.c
+++ b/lib/renderers/x11/window.c
@@ -69,7 +69,7 @@ get_window_width(struct window *window)
     uint32_t width = window->width - 2 * window->hmargin_size;
 
     if(width < WINDOW_MIN_WIDTH || 2 * window->hmargin_size > window->width)
-	width = WINDOW_MIN_WIDTH;
+        width = WINDOW_MIN_WIDTH;
 
     return width;
 }
@@ -218,10 +218,10 @@ bm_x11_window_set_monitor(struct window *window, int32_t monitor)
             window->width = DisplayWidth(window->display, window->screen);
         }
 
-	window->orig_width = window->width;
-	window->orig_x = window->x;
-	window->width = get_window_width(window);
-	window->x += (window->orig_width - window->width) / 2;
+        window->orig_width = window->width;
+        window->orig_x = window->x;
+        window->width = get_window_width(window);
+        window->x += (window->orig_width - window->width) / 2;
 
 #undef INTERSECT
     }
@@ -244,15 +244,15 @@ bm_x11_window_set_align(struct window *window, enum bm_align align)
 void
 bm_x11_window_set_hmargin_size(struct window *window, uint32_t margin)
 {
-	if(window->hmargin_size == margin)
-	    return;
+    if(window->hmargin_size == margin)
+        return;
 
-	window->hmargin_size = margin;
-	window->width = window->orig_width;
-	window->x = window->orig_x;
-	window->width = get_window_width(window);
-	window->x += (window->orig_width - window->width) / 2;
-	bm_x11_window_set_monitor(window, window->monitor);
+    window->hmargin_size = margin;
+    window->width = window->orig_width;
+    window->x = window->orig_x;
+    window->width = get_window_width(window);
+    window->x += (window->orig_width - window->width) / 2;
+    bm_x11_window_set_monitor(window, window->monitor);
 }
 
 bool

--- a/lib/renderers/x11/x11.c
+++ b/lib/renderers/x11/x11.c
@@ -199,11 +199,11 @@ get_displayed_count(const struct bm_menu *menu)
 }
 
 static void
-set_bottom(const struct bm_menu *menu, bool bottom)
+set_align(const struct bm_menu *menu, enum bm_align align)
 {
     struct x11 *x11 = menu->renderer->internal;
     assert(x11);
-    bm_x11_window_set_bottom(&x11->window, bottom);
+    bm_x11_window_set_align(&x11->window, align);
 }
 
 static void
@@ -276,7 +276,7 @@ constructor(struct bm_menu *menu)
 
     XSetClassHint(x11->window.display, x11->window.drawable, (XClassHint[]){{.res_name = (menu->title ? menu->title : "bemenu"), .res_class = "bemenu"}});
 
-    x11->window.bottom = menu->bottom;
+    x11->window.align = menu->align;
     bm_x11_window_set_monitor(&x11->window, menu->monitor);
 
     x11->window.notify.render = bm_cairo_paint;
@@ -295,7 +295,7 @@ register_renderer(struct render_api *api)
     api->get_displayed_count = get_displayed_count;
     api->poll_key = poll_key;
     api->render = render;
-    api->set_bottom = set_bottom;
+    api->set_align = set_align;
     api->set_hmargin_size = set_hmargin_size;
     api->set_monitor = set_monitor;
     api->grab_keyboard = grab_keyboard;

--- a/lib/renderers/x11/x11.c
+++ b/lib/renderers/x11/x11.c
@@ -207,6 +207,14 @@ set_bottom(const struct bm_menu *menu, bool bottom)
 }
 
 static void
+set_hmargin_size(const struct bm_menu *menu, uint32_t margin)
+{
+    struct x11 *x11 = menu->renderer->internal;
+    assert(x11);
+    bm_x11_window_set_hmargin_size(&x11->window, margin);
+}
+
+static void
 set_monitor(const struct bm_menu *menu, int32_t monitor)
 {
     struct x11 *x11 = menu->renderer->internal;
@@ -288,6 +296,7 @@ register_renderer(struct render_api *api)
     api->poll_key = poll_key;
     api->render = render;
     api->set_bottom = set_bottom;
+    api->set_hmargin_size = set_hmargin_size;
     api->set_monitor = set_monitor;
     api->grab_keyboard = grab_keyboard;
     api->priorty = BM_PRIO_GUI;

--- a/lib/renderers/x11/x11.h
+++ b/lib/renderers/x11/x11.h
@@ -31,6 +31,8 @@ struct window {
 
     struct buffer buffer;
     uint32_t x, y, width, height, max_height;
+    uint32_t orig_width, orig_x;
+    uint32_t hmargin_size;
     uint32_t displayed;
 
     int32_t monitor;
@@ -50,6 +52,7 @@ void bm_x11_window_render(struct window *window, const struct bm_menu *menu);
 void bm_x11_window_key_press(struct window *window, XKeyEvent *ev);
 void bm_x11_window_set_monitor(struct window *window, int32_t monitor);
 void bm_x11_window_set_bottom(struct window *window, bool bottom);
+void bm_x11_window_set_hmargin_size(struct window *window, uint32_t margin);
 bool bm_x11_window_create(struct window *window, Display *display);
 void bm_x11_window_destroy(struct window *window);
 

--- a/lib/renderers/x11/x11.h
+++ b/lib/renderers/x11/x11.h
@@ -1,6 +1,8 @@
 #ifndef _BM_X11_H_
 #define _BM_X11_H_
 
+#include "internal.h"
+
 #include <X11/Xlib.h>
 #include <X11/keysym.h>
 
@@ -36,7 +38,7 @@ struct window {
     uint32_t displayed;
 
     int32_t monitor;
-    bool bottom;
+    enum bm_align align;
 
     struct {
         void (*render)(struct cairo *cairo, uint32_t width, uint32_t max_height, const struct bm_menu *menu, struct cairo_paint_result *result);
@@ -51,7 +53,7 @@ struct x11 {
 void bm_x11_window_render(struct window *window, const struct bm_menu *menu);
 void bm_x11_window_key_press(struct window *window, XKeyEvent *ev);
 void bm_x11_window_set_monitor(struct window *window, int32_t monitor);
-void bm_x11_window_set_bottom(struct window *window, bool bottom);
+void bm_x11_window_set_align(struct window *window, enum bm_align align);
 void bm_x11_window_set_hmargin_size(struct window *window, uint32_t margin);
 bool bm_x11_window_create(struct window *window, Display *display);
 void bm_x11_window_destroy(struct window *window);


### PR DESCRIPTION
Adds a`--margin` option which can be used to set the empty space on the left and right of the menu. Also makes the behavior of `--center` more predictable and work on both x11 and wayland. Related to the discussion in #194.