### PR TITLE
lib/renderers/curses/curses.c: always use "%s"-style format for printf()-style functions

### DIFF
--- a/lib/renderers/curses/curses.c
+++ b/lib/renderers/curses/curses.c
@@ -231,7 +231,7 @@ render(const struct bm_menu *menu)
 
     if (menu->title && title_len > 0) {
         attron(COLOR_PAIR(1));
-        mvprintw(0, 0, menu->title);
+        mvprintw(0, 0, "%s", menu->title);
         attroff(COLOR_PAIR(1));
     }
 


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    lib/renderers/curses/curses.c:234:9:
      error: format not a string literal and no format arguments [-Werror=format-security]
      234 |         mvprintw(0, 0, menu->title);
          |         ^~~~~~~~

Let's wrap all the missing places with "%s" format.