### PR TITLE
Fix `--ch` cursor height option parsing

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -270,7 +270,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
         { "line-height",  required_argument, 0, 'H' },
         { "margin",       required_argument, 0, 'M' },
         { "width-factor", required_argument, 0, 'W' },
-        { "ch",           required_argument, 0, 0x118 },
+        { "ch",           required_argument, 0, 0x120 },
         { "fn",           required_argument, 0, 0x101 },
         { "tb",           required_argument, 0, 0x102 },
         { "tf",           required_argument, 0, 0x103 },


### PR DESCRIPTION
It seems the `--ch` option to set the cursor height is no longer working due to our reuse of the option value `0x118`.
This looks to have been introduced in 9b8da124675340c67ce28c488b63da5bdcb45c7c by accident.

This change corrects its value to `0x120` which is expected further down for setting the cursor height:

https://github.com/Cloudef/bemenu/blob/c3a662d0961a696c9739b089bcdfe92cf6a89bfd/client/common/common.c#L380-L382

Fixes: #252

**Testing**

Manually ran:
`LD_LIBRARY_PATH=. BEMENU_RENDERERS=. ./bemenu-run --line-height 32 --ch 16`

Before:
![image](https://user-images.githubusercontent.com/3999823/157831531-8f3eea6b-a9af-4939-9cee-129f1ba69f17.png)

After:
![image](https://user-images.githubusercontent.com/3999823/157831310-11116c07-8866-43ee-b842-adda5344b383.png)