### PR TITLE
Add option to specify horizontal padding in single line mode

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -204,6 +204,7 @@ usage(FILE *out, const char *name)
           " -W, --width-factor    defines the relative width factor of the menu (from 0 to 1). (wx)\n"
           " --ch                  defines the height of the cursor (0 = scales with line height). (wx)\n"
           " --cw                  defines the width of the cursor. (wx)\n"
+          " --hp                  defines the horizontal padding for the entries in single line mode. (wx)\n"
           " --fn                  defines the font to be used ('name [size]'). (wx)\n"
           " --tb                  defines the title background color. (wx)\n"
           " --tf                  defines the title foreground color. (wx)\n"
@@ -275,6 +276,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
         { "width-factor", required_argument, 0, 'W' },
         { "ch",           required_argument, 0, 0x120 },
         { "cw",           required_argument, 0, 0x125 },
+        { "hp",           required_argument, 0, 0x122 },
         { "fn",           required_argument, 0, 0x101 },
         { "tb",           required_argument, 0, 0x102 },
         { "tf",           required_argument, 0, 0x103 },
@@ -389,6 +391,9 @@ do_getopt(struct client *client, int *argc, char **argv[])
             case 0x125:
                 client->cursor_width = strtol(optarg, NULL, 10);
                 break;
+            case 0x122:
+                client->hpadding = strtol(optarg, NULL, 10);
+                break;
             case 0x101:
                 client->font = optarg;
                 break;
@@ -481,6 +486,7 @@ menu_with_options(struct client *client)
     bm_menu_set_line_height(menu, client->line_height);
     bm_menu_set_cursor_height(menu, client->cursor_height);
     bm_menu_set_cursor_width(menu, client->cursor_width);
+    bm_menu_set_hpadding(menu, client->hpadding);
     bm_menu_set_title(menu, client->title);
     bm_menu_set_prefix(menu, client->prefix);
     bm_menu_set_filter_mode(menu, client->filter_mode);

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -15,6 +15,7 @@ struct client {
     uint32_t line_height;
     uint32_t cursor_height;
     uint32_t cursor_width;
+    uint32_t hpadding;
     uint32_t lines;
     uint32_t selected;
     uint32_t monitor;

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -580,6 +580,24 @@ BM_PUBLIC void bm_menu_set_cursor_width(struct bm_menu *menu, uint32_t cursor_wi
 BM_PUBLIC uint32_t bm_menu_get_cursor_width(struct bm_menu *menu);
 
 /**
+ * Set horizontal padding in pixels.
+ * Some renderers such as ncurses may ignore this when it does not make sense.
+ *
+ * @param menu bm_menu instance where to set horizontal padding.
+ * @return uint32_t for horizontal padding
+ */
+BM_PUBLIC void bm_menu_set_hpadding(struct bm_menu *menu, uint32_t hpadding);
+
+/**
+ * Get horizontal padding in pixels.
+ * Some renderers such as ncurses may ignore this when it does not make sense.
+ *
+ * @param menu bm_menu instance where to set horizontal padding.
+ * @return uint32_t for horizontal padding
+ */
+BM_PUBLIC uint32_t bm_menu_get_hpadding(struct bm_menu *menu);
+
+/**
  * Get with of menu in pixels.
  *
  * @param menu bm_menu instance where to get line height.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -280,6 +280,11 @@ struct bm_menu {
     uint32_t cursor_width;
 
     /**
+     * Horizontal Padding.
+     */
+    uint32_t hpadding;
+
+    /**
      * Colors.
      */
     struct bm_hex_color colors[BM_COLOR_LAST];

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -319,6 +319,20 @@ bm_menu_get_cursor_width(struct bm_menu *menu)
     return menu->cursor_width;
 }
 
+void
+bm_menu_set_hpadding(struct bm_menu *menu, uint32_t hpadding)
+{
+    assert(menu);
+    menu->hpadding = hpadding;
+}
+
+uint32_t
+bm_menu_get_hpadding(struct bm_menu *menu)
+{
+    assert(menu);
+    return menu->hpadding;
+}
+
 uint32_t
 bm_menu_get_height(struct bm_menu *menu)
 {

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -27,6 +27,7 @@ struct cairo_paint {
     uint32_t cursor;
     uint32_t cursor_height;
     uint32_t cursor_width;
+    uint32_t hpadding;
     bool draw_cursor;
 
     struct box {
@@ -437,10 +438,11 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
                 bm_cairo_color_from_menu_color(menu, BM_COLOR_ITEM_BG, &paint.bg);
             }
 
-            paint.pos = (struct pos){ cl, vpadding };
-            paint.box = (struct box){ 2, 4, vpadding, -vpadding, 0, height };
+            uint32_t hpadding = (menu->hpadding == 0 ? 2 : menu->hpadding);
+            paint.pos = (struct pos){ cl + (hpadding/2), vpadding };
+            paint.box = (struct box){ hpadding/2, 1.5 * hpadding, vpadding, -vpadding, 0, height };
             bm_cairo_draw_line(cairo, &paint, &result, "%s", (items[i]->text ? items[i]->text : ""));
-            cl += result.x_advance + 2;
+            cl += result.x_advance + (0.5 * hpadding);
             out_result->displayed += (cl < width);
             out_result->height = fmax(out_result->height, result.height);
         }


### PR DESCRIPTION
This PR adds an option to specify the horizontal padding on entries, making it easier to distinguish unique entries.

Closes https://github.com/Cloudef/bemenu/issues/113.