### PR TITLE
Add option to specify cursor width

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -203,6 +203,7 @@ usage(FILE *out, const char *name)
           " -M, --margin          defines the empty space on either side of the menu. (wx)\n"
           " -W, --width-factor    defines the relative width factor of the menu (from 0 to 1). (wx)\n"
           " --ch                  defines the height of the cursor (0 = scales with line height). (wx)\n"
+          " --cw                  defines the width of the cursor. (wx)\n"
           " --fn                  defines the font to be used ('name [size]'). (wx)\n"
           " --tb                  defines the title background color. (wx)\n"
           " --tf                  defines the title foreground color. (wx)\n"
@@ -271,6 +272,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
         { "margin",       required_argument, 0, 'M' },
         { "width-factor", required_argument, 0, 'W' },
         { "ch",           required_argument, 0, 0x120 },
+        { "cw",           required_argument, 0, 0x125 },
         { "fn",           required_argument, 0, 0x101 },
         { "tb",           required_argument, 0, 0x102 },
         { "tf",           required_argument, 0, 0x103 },
@@ -380,6 +382,9 @@ do_getopt(struct client *client, int *argc, char **argv[])
             case 0x120:
                 client->cursor_height = strtol(optarg, NULL, 10);
                 break;
+            case 0x125:
+                client->cursor_width = strtol(optarg, NULL, 10);
+                break;
             case 0x101:
                 client->font = optarg;
                 break;
@@ -465,6 +470,7 @@ menu_with_options(struct client *client)
     bm_menu_set_font(menu, client->font);
     bm_menu_set_line_height(menu, client->line_height);
     bm_menu_set_cursor_height(menu, client->cursor_height);
+    bm_menu_set_cursor_width(menu, client->cursor_width);
     bm_menu_set_title(menu, client->title);
     bm_menu_set_prefix(menu, client->prefix);
     bm_menu_set_filter_mode(menu, client->filter_mode);

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -14,6 +14,7 @@ struct client {
     const char *initial_filter;
     uint32_t line_height;
     uint32_t cursor_height;
+    uint32_t cursor_width;
     uint32_t lines;
     uint32_t selected;
     uint32_t monitor;

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -561,6 +561,23 @@ BM_PUBLIC void bm_menu_set_cursor_height(struct bm_menu *menu, uint32_t cursor_h
 BM_PUBLIC uint32_t bm_menu_get_cursor_height(struct bm_menu *menu);
 
 /**
+ * Set width of cursor in pixels.
+ * Some renderers such as ncurses may ignore this when it does not make sense.
+ *
+ * @param menu bm_menu instance where to set cursor height.
+ * @param cursor_width 0 for default cursor height, > 0 for that many pixels.
+ */
+BM_PUBLIC void bm_menu_set_cursor_width(struct bm_menu *menu, uint32_t cursor_width);
+
+/**
+ * Get width of cursor in pixels.
+ *
+ * @param menu bm_menu instance where to get cursor height.
+ * @return uint32_t for max amount of vertical cursors to be shown.
+ */
+BM_PUBLIC uint32_t bm_menu_get_cursor_width(struct bm_menu *menu);
+
+/**
  * Get with of menu in pixels.
  *
  * @param menu bm_menu instance where to get line height.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -275,6 +275,11 @@ struct bm_menu {
     uint32_t cursor_height;
 
     /**
+     * Cursor width.
+     */
+    uint32_t cursor_width;
+
+    /**
      * Colors.
      */
     struct bm_hex_color colors[BM_COLOR_LAST];

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -303,6 +303,20 @@ bm_menu_get_cursor_height(struct bm_menu *menu)
     return menu->cursor_height;
 }
 
+void
+bm_menu_set_cursor_width(struct bm_menu *menu, uint32_t cursor_width)
+{
+    assert(menu);
+    menu->cursor_width = cursor_width;
+}
+
+uint32_t
+bm_menu_get_cursor_width(struct bm_menu *menu)
+{
+    assert(menu);
+    return menu->cursor_width;
+}
+
 uint32_t
 bm_menu_get_height(struct bm_menu *menu)
 {

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -26,6 +26,7 @@ struct cairo_paint {
     int32_t baseline;
     uint32_t cursor;
     uint32_t cursor_height;
+    uint32_t cursor_width;
     bool draw_cursor;
 
     struct box {
@@ -154,16 +155,20 @@ bm_cairo_draw_line_str(struct cairo *cairo, struct cairo_paint *paint, struct ca
             rect.width = result.x_advance * PANGO_SCALE;
         }
 
+        uint32_t cursor_width = rect.width / PANGO_SCALE;
+        if (paint->cursor_width > 0) {
+            cursor_width = paint->cursor_width;
+        }
         uint32_t cursor_height = fmin(paint->cursor_height == 0 ? line_height : paint->cursor_height, line_height);
         cairo_set_source_rgba(cairo->cr, paint->fg.r, paint->fg.b, paint->fg.g, paint->fg.a);
         cairo_rectangle(cairo->cr,
                 paint->pos.x + paint->box.lx + rect.x / PANGO_SCALE, paint->pos.y - paint->box.ty + ((line_height - cursor_height) / 2),
-                rect.width / PANGO_SCALE, cursor_height);
+                cursor_width, cursor_height);
         cairo_fill(cairo->cr);
 
         cairo_rectangle(cairo->cr,
                 paint->pos.x + paint->box.lx + rect.x / PANGO_SCALE, paint->pos.y - paint->box.ty,
-                rect.width / PANGO_SCALE, line_height);
+                cursor_width, line_height);
         cairo_clip(cairo->cr);
 
         cairo_set_source_rgba(cairo->cr, paint->bg.r, paint->bg.b, paint->bg.g, paint->bg.a);
@@ -296,6 +301,7 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
     paint.draw_cursor = true;
     paint.cursor = menu->cursor;
     paint.cursor_height = menu->cursor_height;
+    paint.cursor_width = menu->cursor_width;
     paint.pos = (struct pos){ (menu->title ? 2 : 0) + result.x_advance, vpadding };
     paint.box = (struct box){ (menu->title ? 2 : 4), 0, vpadding, -vpadding, width - paint.pos.x, height };
 


### PR DESCRIPTION
This PR adds an option to specify the cursor width.

Closes https://github.com/Cloudef/bemenu/issues/152 and sort-of  implements https://github.com/Cloudef/bemenu/issues/181.

Only I-beam and block can be figured through combination of `--ch` and `--cw`. Underline cursors probably requires a re-write of the current cursor drawing code =/