### PR TITLE
Fix missed rendering regressions on Wayland (fixes --grab flag)

### DIFF
--- a/lib/menu.c
+++ b/lib/menu.c
@@ -177,10 +177,14 @@ bm_menu_set_filter(struct bm_menu *menu, const char *filter)
 {
     assert(menu);
 
+    if (strcmp(menu->filter ? menu->filter : "", filter ? filter : ""))
+        menu->dirty = true;
+
     free(menu->filter);
     menu->filter_size = (filter ? strlen(filter) : 0);
     menu->filter = (menu->filter_size > 0 ? bm_strdup(filter) : NULL);
     menu->curses_cursor = (menu->filter ? bm_utf8_string_screen_width(menu->filter) : 0);
+    menu->dirty |= (menu->cursor != menu->filter_size);
     menu->cursor = menu->filter_size;
 }
 

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -26,7 +26,7 @@ render(struct bm_menu *menu)
 
     struct window *window;
     wl_list_for_each(window, &wayland->windows, link) {
-        if (menu->dirty && window->render_pending)
+        if (window->render_pending)
             bm_wl_window_render(window, wayland->display, menu);
     }
     wl_display_flush(wayland->display);


### PR DESCRIPTION
This PR contains two closely related regression fixes (introduced by commit 5a095705d2 and released in versions 0.6.5+), which affect exclusively the Wayland backend.
Both are due to some missed edge cases when managing the `dirty` flag that was introduced in that commit, and for the most part just cause bemenu not to re-render after the items are loaded when using the `--grab`, so bemenu stays at "Loading..." until an unrelated event happens (e.g. a key press) that causes an actual re-render.

 The issue fixed by the first commit can be reproduced with:
```sh
{ echo one; sleep 1; echo two; } | BEMENU_BACKEND=wayland bemenu --grab
```
And causes bemenu to pause at "Loading..." almost 100% of the time.

The issue fixed by the second commit can be reproduced with:
```sh
{ echo one; echo two; } | BEMENU_BACKEND=wayland bemenu --grab
```
And causes bemenu to sometimes (~15% on my PC) pause at "Loading...". Reproduces more often when having some background activity.
