### PR TITLE
Fix Wayland event loop order to avoid missed renders (fixes regressions on #274, #275)

### DIFF
--- a/lib/menu.c
+++ b/lib/menu.c
@@ -1190,7 +1190,7 @@ bm_menu_run_with_pointer(struct bm_menu *menu, struct bm_pointer pointer)
         }
     }
 
-    if (pointer.event_mask & POINTER_EVENT_MOTION) {
+    if (pointer.event_mask & (POINTER_EVENT_ENTER | POINTER_EVENT_MOTION)) {
         menu_point_select(menu, pointer.pos_x, pointer.pos_y, displayed);
     }
 


### PR DESCRIPTION
While #273 fixes the rendering issue on Wayland with the `--grab` flag, it unfortunately also introduced some new regressions (#274, #275).

The cause of both issues is that after #273, the render roop (`render` in wayland.c) looked like this:

1. Render windows if `window->render_pending` is set
2. Wait for events [including a scheduled render, i.e. a frame callback]
3. Schedule render if `menu->dirty` is set
4. Handle events (`return` from `render`) and repeat

The problem with this, is that the `dirty` flag can be set in step (4), but is checked in step (3), so we may go to sleep to wait for more events in (2) without scheduling a render if necessary.

To fix this, this PR changes reorders the render loop to:

1. Schedule render if `menu->dirty` is set
2. Wait for events [including a scheduled render, i.e. a frame callback]
3. Render windows if `window->render_pending` is set
4. Handle events (`return` from `render`) and repeat

So the `menu->dirty` flag is checked at the beginning, right after bemenu has finished handling events and maybe needs to be rendered.

With this, I can no longer reproduce #273, #274 (also tested by @stacyharper) nor #275, and hopefully no related rendering issues on Wayland remain.

[Side note: The reason #274 and #275 worked fine before #273 is because the way the render loop logic worked before, `window->render_pending` was almost always true before waiting for events, even when no renderings were happening. This caused the menu to immediately repaint when `menu->dirty` was later set to true, so things mostly worked fine anyway]

This PR also includes a fix for a very minor issue for pointer events I found while testing: An "enter" event did not cause the highlighted index to be updated, only a "motion" event.