### PR TITLE
Do not highlight entry with initial mouse position

### DIFF
--- a/lib/menu.c
+++ b/lib/menu.c
@@ -1192,7 +1192,7 @@ bm_menu_run_with_pointer(struct bm_menu *menu, struct bm_pointer pointer)
         }
     }
 
-    if (pointer.event_mask & (POINTER_EVENT_ENTER | POINTER_EVENT_MOTION)) {
+    if (pointer.event_mask & POINTER_EVENT_MOTION) {
         menu_point_select(menu, pointer.pos_x, pointer.pos_y, displayed);
     }
 


### PR DESCRIPTION
This reverts commit ef1055eccec850daac8b568726317b4f8f0d4c2a.

As discussed ([here](https://github.com/Cloudef/bemenu/pull/279#issuecomment-1179620822)) this patch solve a marginal issue and cause a very common one. We revert this until we find a way to solve boths.