### PR TITLE
Fix exiting when an unexpected Wayland error occurs.

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -556,7 +556,10 @@ run_menu(const struct client *client, struct bm_menu *menu, void (*item_cb)(cons
     struct bm_touch touch;
     enum bm_run_result status = BM_RUN_RESULT_RUNNING;
     do {
-        bm_menu_render(menu);
+        if (!bm_menu_render(menu)) {
+            status = BM_RUN_RESULT_CANCEL;
+            break;
+        }
         key = bm_menu_poll_key(menu, &unicode);
         pointer = bm_menu_poll_pointer(menu);
         touch = bm_menu_poll_touch(menu);

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -933,7 +933,7 @@ BM_PUBLIC struct bm_item** bm_menu_get_filtered_items(const struct bm_menu *menu
  *
  * @param menu bm_menu instance to be rendered.
  */
-BM_PUBLIC void bm_menu_render(struct bm_menu *menu);
+BM_PUBLIC bool bm_menu_render(struct bm_menu *menu);
 
 /**
  * Trigger filtering of menu manually.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -103,7 +103,7 @@ struct render_api {
     /**
      * Tells underlying renderer to draw the menu.
      */
-    void (*render)(struct bm_menu *menu);
+    bool (*render)(struct bm_menu *menu);
 
     /**
      * Set vertical alignment of the bar.

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -723,13 +723,15 @@ bm_menu_get_filtered_items(const struct bm_menu *menu, uint32_t *out_nmemb)
     return list_get_items(&menu->items, out_nmemb);
 }
 
-void
+bool
 bm_menu_render(struct bm_menu *menu)
 {
     assert(menu);
 
     if (menu->renderer->api.render)
-        menu->renderer->api.render(menu);
+        return menu->renderer->api.render(menu);
+
+    return true;
 }
 
 void

--- a/lib/renderers/curses/curses.c
+++ b/lib/renderers/curses/curses.c
@@ -176,7 +176,7 @@ draw_line(int32_t pair, int32_t y, const char *fmt, ...)
         attroff(COLOR_PAIR(pair));
 }
 
-static void
+static bool
 render(struct bm_menu *menu)
 {
     if (curses.should_terminate) {
@@ -190,7 +190,7 @@ render(struct bm_menu *menu)
         setlocale(LC_CTYPE, "");
 
         if ((curses.stdscreen = initscr()) == NULL)
-            return;
+            return true;
 
         set_escdelay(25);
         flushinp();
@@ -280,6 +280,8 @@ render(struct bm_menu *menu)
         restore_stdin();
         curses.should_terminate = true;
     }
+
+    return true;
 }
 
 static uint32_t

--- a/lib/renderers/x11/x11.c
+++ b/lib/renderers/x11/x11.c
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #include <X11/Xutil.h>
 
-static void
+static bool
 render(struct bm_menu *menu)
 {
     struct x11 *x11 = menu->renderer->internal;
@@ -16,7 +16,7 @@ render(struct bm_menu *menu)
 
     XEvent ev;
     if (XNextEvent(x11->display, &ev) || XFilterEvent(&ev, x11->window.drawable))
-        return;
+        return true;
 
     switch (ev.type) {
         case KeyPress:
@@ -32,6 +32,8 @@ render(struct bm_menu *menu)
             }
             break;
     }
+
+    return true;
 }
 
 static enum bm_key


### PR DESCRIPTION
If an unexpected error was returned from a Wayland API during rendering (e.g. from `wl_display_flush`), the code did set `input.sym = XKB_KEY_Escape`, so that the next call to `poll_key` would return `BM_KEY_ESCAPE` and bemenu would quit.

However, this has been broken since #135, because input.key_pending was not set, so the "fake" `XKB_KEY_Escape` is just ignored, bemenu doesn't quit, but instead, it enters an infinite loop and keeps a CPU core at 100% usage.

The "quick fix" would be to just set `input.key_pending` wherever `input.sym` was set to `XKB_KEY_Escape`. However, to make error handling less error-prone, decouple it from input handling and add an error flag to `(bm_menu_)render` instead.

*Context:* On one of my Sway setups, every few days I find a bemenu process on the background hogging a CPU core. I am not sure how to reproduce the issue, but by attaching gdb, I saw that `wl_display_flush` was setting `errno=EPIPE` yet bemenu was not exiting. It *may* have something to do with launching bemenu like `long_running_process | bemenu --grab`.

(The issue can be synthetically reproduced by changing `wl_display_flush(wayland->display) < 0 && errno != EAGAIN` to `true`.)