### PR TITLE
[Wayland] Anchor top edge of menu to center

### DIFF
--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -211,10 +211,8 @@ get_align_anchor(enum bm_align align)
 {
     uint32_t anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT | ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
 
-    if(align == BM_ALIGN_TOP) {
+    if(align == BM_ALIGN_TOP || align == BM_ALIGN_CENTER) {
         anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
-    } else if(align == BM_ALIGN_CENTER) {
-        anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
     } else {
         anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
     }
@@ -249,7 +247,11 @@ bm_wl_window_render(struct window *window, struct wl_display *display, const str
             break;
 
         struct cairo_paint_result result;
-        window->notify.render(&buffer->cairo, buffer->width, window->max_height, menu, &result);
+        uint32_t max_height = window->max_height;
+        if (menu->align == BM_ALIGN_CENTER) {
+            max_height /= 2;
+        }
+        window->notify.render(&buffer->cairo, buffer->width, max_height, menu, &result);
         window->displayed = result.displayed;
 
         if (window->height == result.height / window->scale)
@@ -348,6 +350,9 @@ bm_wl_window_set_align(struct window *window, struct wl_display *display, enum b
     window->align_anchor = get_align_anchor(window->align);
 
     zwlr_layer_surface_v1_set_anchor(window->layer_surface, window->align_anchor);
+    if (align == BM_ALIGN_CENTER) {
+        zwlr_layer_surface_v1_set_margin(window->layer_surface, window->max_height / 2, 0, 0, 0);
+    }
     wl_surface_commit(window->surface);
     wl_display_roundtrip(display);
 }


### PR DESCRIPTION
Anchor only the top edge of the menu to the center when --center mode is used instead of centering the entire menu. This
prevents the menu from bouncing around as the list is shortened. The issue this fixes is described in this comment: https://github.com/Cloudef/bemenu/issues/194#issuecomment-939280688

For this to work we only anchor to the top instead of the top and the bottom and set a top margin equal to half of the display width.
The max height of the menu also needs to be halved to prevent drawing a menu that overflows the bottom edge of the screen.

Also fixes #289.

This is what it looks like on the main branch when you combine the `--center` and `--list 100` options:

![master-center-list-100](https://user-images.githubusercontent.com/9440455/184431500-b7a041f7-4abb-4ab4-85a5-56c415e69ba4.png)

It's not really centered anymore because the list was so tall it pushed it to the top of the screen.

When the list is filtered bemenu moves down the screen because it gets shorter, causing the absolute center to move:

![main-center-list-10](https://user-images.githubusercontent.com/9440455/184431784-cad8dd0e-d279-42a4-9d6f-b8e8072c99b5.png)

With this patch the top edge of the list is centered, and not the entire list:

![fixed-center-list-100](https://user-images.githubusercontent.com/9440455/184431867-2dca578f-8600-4149-b287-0b815bb5cda2.png)

![fixed-center-list-10](https://user-images.githubusercontent.com/9440455/184431883-c63b89e6-f5c2-48ac-8f11-77befee05025.png)\

Open questions:

- If you aren't using `--list` mode it still works fine, but the 'center' is going to be just slightly further down own the page. We could only apply this fix for list mode to avoid that but it will make things a bit more complex. Any preference there?
- Is there a better way to implement this? I tried setting a `margin_top` property on the window when it's first created but that didn't work since the alignment isn't set yet and we need to know that to determine the margin.
- Should we let you specify a Y position in px or as a percentage instead? I'd personally like to have the menu a bit higher up on the screen rather than dead center.