### PR TITLE
wayland: Damage using buffer coordinates

### DIFF
--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -262,7 +262,7 @@ bm_wl_window_render(struct window *window, struct wl_display *display, const str
         destroy_buffer(buffer);
     }
 
-    wl_surface_damage(window->surface, 0, 0, buffer->width, buffer->height);
+    wl_surface_damage_buffer(window->surface, 0, 0, buffer->width, buffer->height);
     wl_surface_attach(window->surface, buffer->buffer, 0, 0);
     wl_surface_commit(window->surface);
     buffer->busy = true;


### PR DESCRIPTION
The surface was being damaged based on the buffer size. It's more correct to damage using the buffer coordinates.

This is a drive by commit - I haven't actually built the project but this was incorrect before.

For reference: Doing a once over of the code trying to see if I could find anything that would explain this: https://github.com/swaywm/sway/pull/6844#issuecomment-1206564520 (somebody is complaining that bemenu is lagging but I can't reproduce)