### PR TITLE
wayland: Bump version

### DIFF
--- a/lib/renderers/wayland/registry.c
+++ b/lib/renderers/wayland/registry.c
@@ -603,7 +603,7 @@ registry_handle_global(void *data, struct wl_registry *registry, uint32_t id, co
     struct wayland *wayland = data;
 
     if (strcmp(interface, "wl_compositor") == 0) {
-        wayland->compositor = wl_registry_bind(registry, id, &wl_compositor_interface, 3);
+        wayland->compositor = wl_registry_bind(registry, id, &wl_compositor_interface, 4);
     } else if (strcmp(interface, zwlr_layer_shell_v1_interface.name) == 0) {
         wayland->layer_shell = wl_registry_bind(registry, id, &zwlr_layer_shell_v1_interface, 2);
     } else if (strcmp(interface, "wl_seat") == 0) {


### PR DESCRIPTION
The last PR was almost correct but needed a version bump to wl_compositor.

#sway-devel:
```
15:57:47 <baltazar> Nefsen402: btw, I noticed your pr to bemenu and I wanted to test it out but bemenu no longer works after that commit...
15:58:03 <baltazar> it just dies with wl_display@1: error 1: invalid method 9 (since 3 < 4), object wl_surface@14
15:58:21 <bl4ckb0ne> looks like a bemenu mistake
15:58:24 <Nefsen402> Righto - I was half way worried about that
15:58:40 <Nefsen402> We're using a function newer than needed
15:59:02 <bl4ckb0ne> https://github.com/Cloudef/bemenu/blob/c3a662d0961a696c9739b089bcdfe92cf6a89bfd/lib/renderers/wayland/registry.c#L606
15:59:05 <bl4ckb0ne> should be 4
15:59:25 <bl4ckb0ne> https://github.com/Cloudef/bemenu/blob/c3a662d0961a696c9739b089bcdfe92cf6a89bfd/lib/renderers/wayland/registry.c#L623 can also probably yeet this with wl_output 4 fwiw
15:59:38 <Nefsen402> Don't know what the best solution is, revert and just pass in MAX_INT for damage and remain compatible with the old version
15:59:41 <Nefsen402> or bump the version
16:00:11 <bl4ckb0ne> bump it
16:00:14 <Nefsen402> k
16:01:25 <bl4ckb0ne> hm not sure what sets the version of wl_surface
16:01:36 <bl4ckb0ne> but i guess the wl_compositor
16:01:50 cabal704 has joined
16:01:52 <Nefsen402> Guess I'm gonna build it
16:01:55 <Nefsen402> just to make sure
```