### PR TITLE
Add support to disable pointer, touch and keyboard events

### DIFF
--- a/client/common/common.h
+++ b/client/common/common.h
@@ -30,6 +30,9 @@ struct client {
     bool ifne;
     bool no_overlap;
     bool no_spacing;
+    bool no_cursor;
+    bool no_touch;
+    bool no_keyboard;
     bool force_fork, fork;
     bool no_exec;
     bool password;


### PR DESCRIPTION
Sometimes you don't want the pointer/touch/keyboard to have any influence on the menu (e.g. if you mainly use the keyboard, you don't want the mouse to select an item by accident).

closes #299