### PR TITLE
Fix --filter

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -569,6 +569,10 @@ menu_with_options(struct client *client)
 enum bm_run_result
 run_menu(const struct client *client, struct bm_menu *menu, void (*item_cb)(const struct client *client, struct bm_item *item))
 {
+    bm_menu_set_highlighted_index(menu, client->selected);
+    bm_menu_grab_keyboard(menu, true);
+    bm_menu_set_filter(menu, client->initial_filter);
+
     {
     uint32_t total_item_count;
     struct bm_item **items = bm_menu_get_items(menu, &total_item_count);
@@ -583,10 +587,6 @@ run_menu(const struct client *client, struct bm_menu *menu, void (*item_cb)(cons
     }
 
     }
-
-    bm_menu_set_highlighted_index(menu, client->selected);
-    bm_menu_grab_keyboard(menu, true);
-    bm_menu_set_filter(menu, client->initial_filter);
 
     uint32_t unicode;
     enum bm_key key = BM_KEY_NONE;

--- a/client/common/common.c
+++ b/client/common/common.c
@@ -322,7 +322,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
     for (optind = 0;;) {
         int32_t opt;
 
-        if ((opt = getopt_long(*argc, *argv, "hviwxcl:I:p:P:I:bfm:H:M:W:B:nsCTK", opts, NULL)) < 0)
+        if ((opt = getopt_long(*argc, *argv, "hviwxcl:I:p:P:I:bfF:m:H:M:W:B:nsCTK", opts, NULL)) < 0)
             break;
 
         switch (opt) {

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -54,7 +54,8 @@ schedule_windows_render_if_dirty(struct bm_menu *menu, struct wayland *wayland) 
             // be(re)created. We need to do the render ASAP (not schedule it) because otherwise,
             // since we lack a window, we may not receive further events and will get deadlocked
             render_windows_if_pending(menu, wayland);
-        } else if (menu->dirty) {
+        }
+        if (menu->dirty) {
             bm_wl_window_schedule_render(window);
         }
     }


### PR DESCRIPTION
- wayland: don't chomp dirty state when window is pending
- common: actually parse -F using getopt
- Apply initial filter before evaluating accept-single
