### PR TITLE
Add rounded corners/Border radius(Addresses issue #319)

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -208,6 +208,7 @@ usage(FILE *out, const char *name)
           " -M, --margin          defines the empty space on either side of the menu. (wx)\n"
           " -W, --width-factor    defines the relative width factor of the menu (from 0 to 1). (wx)\n"
           " -B, --border          defines the width of the border in pixels around the menu. (wx)\n"
+          " -R  --border-radius   defines the radius of the border around the menu (0 = no curved borders).\n"
           " --ch                  defines the height of the cursor (0 = scales with line height). (wx)\n"
           " --cw                  defines the width of the cursor. (wx)\n"
           " --hp                  defines the horizontal padding for the entries in single line mode. (wx)\n"
@@ -286,6 +287,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
         { "margin",       required_argument, 0, 'M' },
         { "width-factor", required_argument, 0, 'W' },
         { "border",       required_argument, 0, 'B' },
+        { "border-radius",required_argument, 0, 'R' },
         { "ch",           required_argument, 0, 0x120 },
         { "cw",           required_argument, 0, 0x125 },
         { "hp",           required_argument, 0, 0x122 },
@@ -322,7 +324,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
     for (optind = 0;;) {
         int32_t opt;
 
-        if ((opt = getopt_long(*argc, *argv, "hviwxcl:I:p:P:I:bfF:m:H:M:W:B:nsCTK", opts, NULL)) < 0)
+        if ((opt = getopt_long(*argc, *argv, "hviwxcl:I:p:P:I:bfF:m:H:M:W:B:R:nsCTK", opts, NULL)) < 0)
             break;
 
         switch (opt) {
@@ -411,6 +413,9 @@ do_getopt(struct client *client, int *argc, char **argv[])
                 break;
             case 'B':
                 client->border_size = strtol(optarg, NULL, 10);
+                break;
+            case 'R':
+                client->border_radius = strtol(optarg, NULL, 10);
                 break;
             case 0x120:
                 client->cursor_height = strtol(optarg, NULL, 10);
@@ -543,6 +548,7 @@ menu_with_options(struct client *client)
     bm_menu_set_password(menu, client->password);
     bm_menu_set_width(menu, client->hmargin_size, client->width_factor);
     bm_menu_set_border_size(menu, client->border_size);
+    bm_menu_set_border_radius(menu, client->border_radius);
     bm_menu_set_key_binding(menu, client->key_binding);
 
     if (client->center) {

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -21,6 +21,7 @@ struct client {
     uint32_t monitor;
     uint32_t hmargin_size;
     uint32_t border_size;
+    uint32_t border_radius;
     float width_factor;
     bool bottom;
     bool center;

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -645,6 +645,25 @@ BM_PUBLIC void bm_menu_set_border_size(struct bm_menu* menu, uint32_t border_siz
 BM_PUBLIC uint32_t bm_menu_get_border_size(struct bm_menu* menu);
 
 /**
+ * Set the radius of the border for the bar
+ *
+ * @param menu bm_menu to get border radius from.
+ * @return border radius of the menu.
+ */
+
+BM_PUBLIC void bm_menu_set_border_radius(struct bm_menu* menu, uint32_t border_radius);
+
+/**
+ * Get the size of the border for the bar
+ *
+ * @param menu bm_menu to get border radius from.
+ * @return border radius of the menu.
+ */
+
+BM_PUBLIC uint32_t bm_menu_get_border_radius(struct bm_menu* menu);
+
+
+/**
  * Set a hexadecimal color for element.
  *
  * @param menu bm_menu instance where to set color.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -383,6 +383,11 @@ struct bm_menu {
     uint32_t border_size;
 
     /**
+     * Border radius
+     */
+    uint32_t border_radius;
+
+    /**
      * Is menu grabbed?
      */
     bool grabbed;

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -360,6 +360,20 @@ bm_menu_get_border_size(struct bm_menu* menu)
     return menu->border_size;
 }
 
+void
+bm_menu_set_border_radius(struct bm_menu* menu, uint32_t border_radius)
+{
+    assert(menu);
+    menu->border_radius = border_radius;
+}
+
+uint32_t
+bm_menu_get_border_radius(struct bm_menu* menu)
+{
+    assert(menu);
+    return menu->border_radius;
+}
+
 uint32_t
 bm_menu_get_height(struct bm_menu *menu)
 {

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -261,12 +261,12 @@ static inline void
 bm_cairo_draw_rounded_path(cairo_t *cr, double x, double y, double width, double height, double radius)
 {
     double degrees = M_PI / 180;
-    cairo_new_sub_path (cr);
-    cairo_arc (cr, x + width - radius, y + radius, radius, -90 * degrees, 0 * degrees);
-    cairo_arc (cr, x + width - radius, y + height - radius, radius, 0 * degrees, 90 * degrees);
-    cairo_arc (cr, x + radius, y + height - radius, radius, 90 * degrees, 180 * degrees);
-    cairo_arc (cr, x + radius, y + radius, radius, 180 * degrees, 270 * degrees);
-    cairo_close_path (cr);
+    cairo_new_sub_path(cr);
+    cairo_arc(cr, x + width - radius, y + radius, radius, -90 * degrees, 0 * degrees);
+    cairo_arc(cr, x + width - radius, y + height - radius, radius, 0 * degrees, 90 * degrees);
+    cairo_arc(cr, x + radius, y + height - radius, radius, 90 * degrees, 180 * degrees);
+    cairo_arc(cr, x + radius, y + radius, radius, 180 * degrees, 270 * degrees);
+    cairo_close_path(cr);
 }
 
 static inline void
@@ -483,7 +483,11 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
     // Draw borders
     bm_cairo_color_from_menu_color(menu, BM_COLOR_BORDER, &paint.fg);
     cairo_set_source_rgba(cairo->cr, paint.fg.r, paint.fg.b, paint.fg.g, paint.fg.a);
-    bm_cairo_draw_rounded_path(cairo->cr, 0, 0, width + border_size, (height * (page_length + 1)) + (2 * border_size), border_radius);
+    if (!border_radius) {
+        cairo_rectangle(cairo->cr, 0, 0, width + border_size, (height * (page_length + 1)) + (2 * border_size));
+    } else {
+        bm_cairo_draw_rounded_path(cairo->cr, 0, 0, width + border_size, (height * (page_length + 1)) + (2 * border_size), border_radius);
+    }
     cairo_set_line_width(cairo->cr, 2 * menu->border_size);
     cairo_stroke(cairo->cr);
 

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -258,6 +258,18 @@ bm_cairo_entry_message(char *entry_text, bool highlighted, uint32_t event_feedba
 }
 
 static inline void
+bm_cairo_draw_rounded_path(cairo_t *cr, double x, double y, double width, double height, double radius)
+{
+    double degrees = M_PI / 180;
+    cairo_new_sub_path (cr);
+    cairo_arc (cr, x + width - radius, y + radius, radius, -90 * degrees, 0 * degrees);
+    cairo_arc (cr, x + width - radius, y + height - radius, radius, 0 * degrees, 90 * degrees);
+    cairo_arc (cr, x + radius, y + height - radius, radius, 90 * degrees, 180 * degrees);
+    cairo_arc (cr, x + radius, y + radius, radius, 180 * degrees, 270 * degrees);
+    cairo_close_path (cr);
+}
+
+static inline void
 bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const struct bm_menu *menu, struct cairo_paint_result *out_result)
 {
     assert(cairo && menu && out_result);
@@ -281,6 +293,8 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
     width -= border_size;
     uint32_t height = fmin(fmax(menu->line_height, ascii_height), max_height);
     uint32_t vpadding = (height - ascii_height)/2;
+
+    uint32_t border_radius = menu->border_radius;
 
     cairo_set_source_rgba(cairo->cr, 0, 0, 0, 0);
     cairo_rectangle(cairo->cr, 0, 0, width, height);
@@ -469,7 +483,7 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
     // Draw borders
     bm_cairo_color_from_menu_color(menu, BM_COLOR_BORDER, &paint.fg);
     cairo_set_source_rgba(cairo->cr, paint.fg.r, paint.fg.b, paint.fg.g, paint.fg.a);
-    cairo_rectangle(cairo->cr, 0, 0, width + border_size, (height * (page_length + 1)) + (2 * border_size));
+    bm_cairo_draw_rounded_path(cairo->cr, 0, 0, width + border_size, (height * (page_length + 1)) + (2 * border_size), border_radius);
     cairo_set_line_width(cairo->cr, 2 * menu->border_size);
     cairo_stroke(cairo->cr);
 


### PR DESCRIPTION
Added the command line option "**-R**" to specify border radius, default **0**/_no_ curved borders. Going off of the issue I was unsure if to make the colors outside the radius transparent or not(Edits/Another PR is welcome to add this, hopefully I explained the problem).

I was unsure exactly what to write for the **common.c** description of the option, suggestions are welcome.

Note: Increasing the border radius too **high** with a **little** border size will cause some overlapping issues with the border.

Closes #319 