### PR TITLE
Add Match/Page Counter(Addresses #204)

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -549,8 +549,6 @@ menu_with_options(struct client *client)
     bm_menu_set_width(menu, client->hmargin_size, client->width_factor);
     bm_menu_set_border_size(menu, client->border_size);
     bm_menu_set_border_radius(menu, client->border_radius);
-    bm_menu_set_total_item_count(menu, client->total_item_count);
-    bm_menu_set_filtered_item_count(menu, client->filtered_item_count);
     bm_menu_set_key_binding(menu, client->key_binding);
 
     if (client->center) {
@@ -584,8 +582,6 @@ run_menu(const struct client *client, struct bm_menu *menu, void (*item_cb)(cons
     {
     uint32_t total_item_count;
     struct bm_item **items = bm_menu_get_items(menu, &total_item_count);
-
-    bm_menu_set_total_item_count(menu, total_item_count);
 
     if (client->ifne && total_item_count == 0) {
         return BM_RUN_RESULT_CANCEL;

--- a/client/common/common.c
+++ b/client/common/common.c
@@ -549,6 +549,7 @@ menu_with_options(struct client *client)
     bm_menu_set_width(menu, client->hmargin_size, client->width_factor);
     bm_menu_set_border_size(menu, client->border_size);
     bm_menu_set_border_radius(menu, client->border_radius);
+    bm_menu_set_total_item_count(menu, client->total_item_count);
     bm_menu_set_key_binding(menu, client->key_binding);
 
     if (client->center) {
@@ -582,6 +583,8 @@ run_menu(const struct client *client, struct bm_menu *menu, void (*item_cb)(cons
     {
     uint32_t total_item_count;
     struct bm_item **items = bm_menu_get_items(menu, &total_item_count);
+
+    bm_menu_set_total_item_count(menu, total_item_count);
 
     if (client->ifne && total_item_count == 0) {
         return BM_RUN_RESULT_CANCEL;

--- a/client/common/common.c
+++ b/client/common/common.c
@@ -183,6 +183,7 @@ usage(FILE *out, const char *name)
           " -K, --no-keyboard     ignore keyboard events.\n"
           " --binding             use alternative key bindings. Available options: vim\n"
           " --scrollbar           display scrollbar. (none (default), always, autohide)\n"
+          " --counter             display a matched/total items counter. (none (default), always)\n"
           " --accept-single       immediately return if there is only one item.\n"
           " --ifne                only display menu if there are items.\n"
           " --fork                always fork. (bemenu-run)\n"
@@ -271,6 +272,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
         { "prefix",       required_argument, 0, 'P' },
         { "password",     no_argument,       0, 'x' },
         { "scrollbar",    required_argument, 0, 0x100 },
+        { "counter",      required_argument, 0, 0x10a },
         { "accept-single",no_argument,       0, 0x11a },
         { "ifne",         no_argument,       0, 0x117 },
         { "fork",         no_argument,       0, 0x118 },
@@ -361,6 +363,9 @@ do_getopt(struct client *client, int *argc, char **argv[])
                 break;
             case 0x100:
                 client->scrollbar = (!strcmp(optarg, "none") ? BM_SCROLLBAR_NONE : (!strcmp(optarg, "always") ? BM_SCROLLBAR_ALWAYS : (!strcmp(optarg, "autohide") ? BM_SCROLLBAR_AUTOHIDE : BM_SCROLLBAR_NONE)));
+                break;
+            case 0x10a:
+                client->counter = (!strcmp(optarg, "always"));
                 break;
             case 0x11a:
                 client->accept_single = true;
@@ -543,6 +548,7 @@ menu_with_options(struct client *client)
     bm_menu_set_monitor(menu, client->monitor);
     bm_menu_set_monitor_name(menu, client->monitor_name);
     bm_menu_set_scrollbar(menu, client->scrollbar);
+    bm_menu_set_counter(menu, client->counter);
     bm_menu_set_panel_overlap(menu, !client->no_overlap);
     bm_menu_set_spacing(menu, !client->no_spacing);
     bm_menu_set_password(menu, client->password);

--- a/client/common/common.c
+++ b/client/common/common.c
@@ -550,6 +550,7 @@ menu_with_options(struct client *client)
     bm_menu_set_border_size(menu, client->border_size);
     bm_menu_set_border_radius(menu, client->border_radius);
     bm_menu_set_total_item_count(menu, client->total_item_count);
+    bm_menu_set_filtered_item_count(menu, client->filtered_item_count);
     bm_menu_set_key_binding(menu, client->key_binding);
 
     if (client->center) {

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -27,6 +27,7 @@ struct client {
     bool center;
     bool grab;
     bool wrap;
+    bool counter;
     bool accept_single;
     bool ifne;
     bool no_overlap;

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -22,8 +22,6 @@ struct client {
     uint32_t hmargin_size;
     uint32_t border_size;
     uint32_t border_radius;
-    uint32_t total_item_count;
-    uint32_t filtered_item_count;
     float width_factor;
     bool bottom;
     bool center;

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -23,6 +23,7 @@ struct client {
     uint32_t border_size;
     uint32_t border_radius;
     uint32_t total_item_count;
+    uint32_t filtered_item_count;
     float width_factor;
     bool bottom;
     bool center;

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -22,6 +22,7 @@ struct client {
     uint32_t hmargin_size;
     uint32_t border_size;
     uint32_t border_radius;
+    uint32_t total_item_count;
     float width_factor;
     bool bottom;
     bool center;

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -663,22 +663,39 @@ BM_PUBLIC void bm_menu_set_border_radius(struct bm_menu* menu, uint32_t border_r
 BM_PUBLIC uint32_t bm_menu_get_border_radius(struct bm_menu* menu);
 
 /**
- * Set the total amount of items in the menu(displayed on the counter).
+ * Set the total amount of items(displayed on the counter).
  *
  * @param menu bm_menu to get the total amount of items from.
- * @return total amount of items in the menu.
+ * @return total amount of items.
  */
 
 BM_PUBLIC uint32_t bm_menu_set_total_item_count(struct bm_menu* menu, uint32_t total_item_count);
 
 /**
- * Get the total amount of items in the menu(displayed on the counter).
+ * Get the total amount of items(displayed on the counter).
  *
  * @param menu bm_menu to get the total amount of items from.
- * @return total amount of items in the menu.
+ * @return total amount of items.
  */
 
 BM_PUBLIC uint32_t bm_menu_get_total_item_count(struct bm_menu* menu);
+
+/**
+ * Set the filtered item count(displayed on the counter).
+ *
+ * @param menu bmenu to get the filtered item count from.
+ * @return filtered item count
+ */
+BM_PUBLIC uint32_t bm_menu_set_filtered_item_count(struct bm_menu* menu, uint32_t filtered_item_count);
+
+/**
+ * Get the filtered item count(displayed on the counter).
+ *
+ * @param menu bmenu to get the filtered item count from.
+ * @return filtered item count
+ */
+
+BM_PUBLIC uint32_t bm_menu_get_filtered_item_count(struct bm_menu* menu);
 
 /**
  * Set a hexadecimal color for element.

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -663,41 +663,6 @@ BM_PUBLIC void bm_menu_set_border_radius(struct bm_menu* menu, uint32_t border_r
 BM_PUBLIC uint32_t bm_menu_get_border_radius(struct bm_menu* menu);
 
 /**
- * Set the total amount of items(displayed on the counter).
- *
- * @param menu bm_menu to get the total amount of items from.
- * @return total amount of items.
- */
-
-BM_PUBLIC uint32_t bm_menu_set_total_item_count(struct bm_menu* menu, uint32_t total_item_count);
-
-/**
- * Get the total amount of items(displayed on the counter).
- *
- * @param menu bm_menu to get the total amount of items from.
- * @return total amount of items.
- */
-
-BM_PUBLIC uint32_t bm_menu_get_total_item_count(struct bm_menu* menu);
-
-/**
- * Set the filtered item count(displayed on the counter).
- *
- * @param menu bmenu to get the filtered item count from.
- * @return filtered item count
- */
-BM_PUBLIC uint32_t bm_menu_set_filtered_item_count(struct bm_menu* menu, uint32_t filtered_item_count);
-
-/**
- * Get the filtered item count(displayed on the counter).
- *
- * @param menu bmenu to get the filtered item count from.
- * @return filtered item count
- */
-
-BM_PUBLIC uint32_t bm_menu_get_filtered_item_count(struct bm_menu* menu);
-
-/**
  * Set a hexadecimal color for element.
  *
  * @param menu bm_menu instance where to set color.

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -662,6 +662,23 @@ BM_PUBLIC void bm_menu_set_border_radius(struct bm_menu* menu, uint32_t border_r
 
 BM_PUBLIC uint32_t bm_menu_get_border_radius(struct bm_menu* menu);
 
+/**
+ * Set the total amount of items in the menu(displayed on the counter).
+ *
+ * @param menu bm_menu to get the total amount of items from.
+ * @return total amount of items in the menu.
+ */
+
+BM_PUBLIC uint32_t bm_menu_set_total_item_count(struct bm_menu* menu, uint32_t total_item_count);
+
+/**
+ * Get the total amount of items in the menu(displayed on the counter).
+ *
+ * @param menu bm_menu to get the total amount of items from.
+ * @return total amount of items in the menu.
+ */
+
+BM_PUBLIC uint32_t bm_menu_get_total_item_count(struct bm_menu* menu);
 
 /**
  * Set a hexadecimal color for element.

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -698,6 +698,24 @@ BM_PUBLIC void bm_menu_set_scrollbar(struct bm_menu *menu, enum bm_scrollbar_mod
 BM_PUBLIC enum bm_scrollbar_mode bm_menu_get_scrollbar(struct bm_menu *menu);
 
 /**
+ * Set the counter display mode.
+ *
+ * @param menu bm_menu to set the counter for.
+ * @param display mode to be set.
+ */
+
+BM_PUBLIC void bm_menu_set_counter(struct bm_menu *menu, bool mode);
+
+/**
+ * Get the counter display mode.
+ *
+ * @param menu bm_menu to get the counter from.
+ * @return current counter display mode
+ */
+
+BM_PUBLIC bool bm_menu_get_counter(struct bm_menu *menu);
+
+/**
  * Set the vertical alignment of the bar.
  *
  * @param menu bm_menu to set alignment for.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -388,9 +388,14 @@ struct bm_menu {
     uint32_t border_radius;
 
     /**
-     * Total amount of items in the menu
+     * Total amount of items
      */
     uint32_t total_item_count;
+
+    /**
+     * Filtered item count
+     */
+    uint32_t filtered_item_count;
 
     /**
      * Is menu grabbed?

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -358,6 +358,11 @@ struct bm_menu {
     enum bm_scrollbar_mode scrollbar;
 
     /**
+     * Current counter display mode.
+     */
+    bool counter;
+
+    /**
      * Should selection be wrapped?
      */
     bool wrap;

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -388,16 +388,6 @@ struct bm_menu {
     uint32_t border_radius;
 
     /**
-     * Total amount of items
-     */
-    uint32_t total_item_count;
-
-    /**
-     * Filtered item count
-     */
-    uint32_t filtered_item_count;
-
-    /**
      * Is menu grabbed?
      */
     bool grabbed;

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -388,6 +388,11 @@ struct bm_menu {
     uint32_t border_radius;
 
     /**
+     * Total amount of items in the menu
+     */
+    uint32_t total_item_count;
+
+    /**
      * Is menu grabbed?
      */
     bool grabbed;

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -375,34 +375,6 @@ bm_menu_get_border_radius(struct bm_menu* menu)
 }
 
 uint32_t
-bm_menu_set_total_item_count(struct bm_menu* menu, uint32_t total_item_count)
-{
-    assert(menu);
-    menu->total_item_count = total_item_count;
-}
-
-uint32_t
-bm_menu_get_total_item_count(struct bm_menu* menu)
-{
-    assert(menu);
-    return menu->total_item_count;
-}
-
-uint32_t
-bm_menu_set_filtered_item_count(struct bm_menu* menu, uint32_t filtered_item_count)
-{
-    assert(menu);
-    menu->filtered_item_count = filtered_item_count;
-}
-
-uint32_t
-bm_menu_get_filtered_item_count(struct bm_menu* menu)
-{
-    assert(menu);
-    return menu->filtered_item_count;
-}
-
-uint32_t
 bm_menu_get_height(struct bm_menu *menu)
 {
     assert(menu);
@@ -794,15 +766,13 @@ bm_menu_filter(struct bm_menu *menu)
 
     char addition = 0;
     size_t len = (menu->filter ? strlen(menu->filter) : 0);
-    uint32_t count;
 
     if (!len || !menu->items.items || menu->items.count <= 0) {
         list_free_list(&menu->filtered);
         free(menu->old_filter);
         menu->old_filter = NULL;
 
-        count = menu->total_item_count;
-        bm_menu_set_filtered_item_count(menu, count);
+        menu->filtered.count = menu->items.count;
         return;
     }
 
@@ -810,19 +780,17 @@ bm_menu_filter(struct bm_menu *menu)
         size_t oldLen = strlen(menu->old_filter);
         addition = (oldLen < len && !memcmp(menu->old_filter, menu->filter, oldLen));
     }
-    
     if (menu->old_filter && addition && menu->filtered.count <= 0)
         return;
 
     if (menu->old_filter && !strcmp(menu->filter, menu->old_filter))
         return;
 
+    uint32_t count;
     struct bm_item **filtered = filter_func[menu->filter_mode](menu, addition, &count);
 
     list_set_items_no_copy(&menu->filtered, filtered, count);
     bm_menu_set_highlighted_index(menu, 0);
-
-    bm_menu_set_filtered_item_count(menu, count);
 
     free(menu->old_filter);
     menu->old_filter = bm_strdup(menu->filter);

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -447,6 +447,18 @@ bm_menu_get_scrollbar(struct bm_menu *menu)
 }
 
 void
+bm_menu_set_counter(struct bm_menu *menu, bool mode)
+{
+    menu->counter = mode;
+}
+
+bool
+bm_menu_get_counter(struct bm_menu *menu)
+{
+    return menu->counter;
+}
+
+void
 bm_menu_set_align(struct bm_menu *menu, enum bm_align align)
 {
     assert(menu);

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -389,6 +389,20 @@ bm_menu_get_total_item_count(struct bm_menu* menu)
 }
 
 uint32_t
+bm_menu_set_filtered_item_count(struct bm_menu* menu, uint32_t filtered_item_count)
+{
+    assert(menu);
+    menu->filtered_item_count = filtered_item_count;
+}
+
+uint32_t
+bm_menu_get_filtered_item_count(struct bm_menu* menu)
+{
+    assert(menu);
+    return menu->filtered_item_count;
+}
+
+uint32_t
 bm_menu_get_height(struct bm_menu *menu)
 {
     assert(menu);
@@ -780,11 +794,15 @@ bm_menu_filter(struct bm_menu *menu)
 
     char addition = 0;
     size_t len = (menu->filter ? strlen(menu->filter) : 0);
+    uint32_t count;
 
     if (!len || !menu->items.items || menu->items.count <= 0) {
         list_free_list(&menu->filtered);
         free(menu->old_filter);
         menu->old_filter = NULL;
+
+        count = menu->total_item_count;
+        bm_menu_set_filtered_item_count(menu, count);
         return;
     }
 
@@ -792,18 +810,19 @@ bm_menu_filter(struct bm_menu *menu)
         size_t oldLen = strlen(menu->old_filter);
         addition = (oldLen < len && !memcmp(menu->old_filter, menu->filter, oldLen));
     }
-
+    
     if (menu->old_filter && addition && menu->filtered.count <= 0)
         return;
 
     if (menu->old_filter && !strcmp(menu->filter, menu->old_filter))
         return;
 
-    uint32_t count;
     struct bm_item **filtered = filter_func[menu->filter_mode](menu, addition, &count);
 
     list_set_items_no_copy(&menu->filtered, filtered, count);
     bm_menu_set_highlighted_index(menu, 0);
+
+    bm_menu_set_filtered_item_count(menu, count);
 
     free(menu->old_filter);
     menu->old_filter = bm_strdup(menu->filter);

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -771,8 +771,6 @@ bm_menu_filter(struct bm_menu *menu)
         list_free_list(&menu->filtered);
         free(menu->old_filter);
         menu->old_filter = NULL;
-
-        menu->filtered.count = menu->items.count;
         return;
     }
 

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -375,6 +375,20 @@ bm_menu_get_border_radius(struct bm_menu* menu)
 }
 
 uint32_t
+bm_menu_set_total_item_count(struct bm_menu* menu, uint32_t total_item_count)
+{
+    assert(menu);
+    menu->total_item_count = total_item_count;
+}
+
+uint32_t
+bm_menu_get_total_item_count(struct bm_menu* menu)
+{
+    assert(menu);
+    return menu->total_item_count;
+}
+
+uint32_t
 bm_menu_get_height(struct bm_menu *menu)
 {
     assert(menu);

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -480,8 +480,8 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
             paint.box = (struct box){ 1, 2, vpadding, -vpadding, 0, height };
             bm_cairo_draw_line(cairo, &paint, &result, ">");
         }
-        char counter[1024];
-        sprintf(counter, "[%u/%u]", filtered_item_count, total_item_count);
+        char counter[128];
+        snprintf(counter, sizeof(counter), "[%u/%u]", filtered_item_count, total_item_count);
         bm_pango_get_text_extents(cairo, &paint, &result, counter);
         paint.pos = (struct pos){ width/cairo->scale - result.x_advance - 10, vpadding + border_size };
         paint.box = (struct box){ 1, 2, vpadding, -vpadding, 0, height };

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -296,6 +296,8 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
 
     uint32_t border_radius = menu->border_radius;
 
+    uint32_t total_item_count = menu->total_item_count;
+
     cairo_set_source_rgba(cairo->cr, 0, 0, 0, 0);
     cairo_rectangle(cairo->cr, 0, 0, width, height);
 
@@ -469,15 +471,21 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
             out_result->displayed += (cl < width);
             out_result->height = fmax(out_result->height, result.height);
         }
-
+        bm_cairo_color_from_menu_color(menu, BM_COLOR_FILTER_FG, &paint.fg);
+        bm_cairo_color_from_menu_color(menu, BM_COLOR_FILTER_BG, &paint.bg);
         if (menu->wrap || menu->index + 1 < count) {
-            bm_cairo_color_from_menu_color(menu, BM_COLOR_FILTER_FG, &paint.fg);
-            bm_cairo_color_from_menu_color(menu, BM_COLOR_FILTER_BG, &paint.bg);
             bm_pango_get_text_extents(cairo, &paint, &result, ">");
             paint.pos = (struct pos){ width/cairo->scale - result.x_advance - 2, vpadding + border_size };
             paint.box = (struct box){ 1, 2, vpadding, -vpadding, 0, height };
             bm_cairo_draw_line(cairo, &paint, &result, ">");
         }
+        unsigned int current_item_count = 6;
+        char counter[1024];
+        sprintf(counter, "[%u/%u]", current_item_count, total_item_count);
+        bm_pango_get_text_extents(cairo, &paint, &result, counter);
+        paint.pos = (struct pos){ width/cairo->scale - result.x_advance - 10, vpadding + border_size };
+        paint.box = (struct box){ 1, 2, vpadding, -vpadding, 0, height };
+        bm_cairo_draw_line(cairo, &paint, &result, counter);
     }
 
     // Draw borders

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -297,6 +297,7 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
     uint32_t border_radius = menu->border_radius;
 
     uint32_t total_item_count = menu->total_item_count;
+    uint32_t filtered_item_count = menu->filtered_item_count;
 
     cairo_set_source_rgba(cairo->cr, 0, 0, 0, 0);
     cairo_rectangle(cairo->cr, 0, 0, width, height);
@@ -479,9 +480,8 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
             paint.box = (struct box){ 1, 2, vpadding, -vpadding, 0, height };
             bm_cairo_draw_line(cairo, &paint, &result, ">");
         }
-        unsigned int current_item_count = 6;
         char counter[1024];
-        sprintf(counter, "[%u/%u]", current_item_count, total_item_count);
+        sprintf(counter, "[%u/%u]", filtered_item_count, total_item_count);
         bm_pango_get_text_extents(cairo, &paint, &result, counter);
         paint.pos = (struct pos){ width/cairo->scale - result.x_advance - 10, vpadding + border_size };
         paint.box = (struct box){ 1, 2, vpadding, -vpadding, 0, height };

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -482,10 +482,10 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
         }
         char counter[128];
         snprintf(counter, sizeof(counter), "[%u/%u]", filtered_item_count, total_item_count);
-        bm_pango_get_text_extents(cairo, &paint, &result, counter);
+        bm_pango_get_text_extents(cairo, &paint, &result, "%s", counter);
         paint.pos = (struct pos){ width/cairo->scale - result.x_advance - 10, vpadding + border_size };
         paint.box = (struct box){ 1, 2, vpadding, -vpadding, 0, height };
-        bm_cairo_draw_line(cairo, &paint, &result, counter);
+        bm_cairo_draw_line(cairo, &paint, &result, "%s", counter);
     }
 
     // Draw borders

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -296,8 +296,8 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
 
     uint32_t border_radius = menu->border_radius;
 
-    uint32_t total_item_count = menu->total_item_count;
-    uint32_t filtered_item_count = menu->filtered_item_count;
+    uint32_t total_item_count = menu->items.count;
+    uint32_t filtered_item_count = menu->filtered.count;
 
     cairo_set_source_rgba(cairo->cr, 0, 0, 0, 0);
     cairo_rectangle(cairo->cr, 0, 0, width, height);

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -297,7 +297,7 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
     uint32_t border_radius = menu->border_radius;
 
     uint32_t total_item_count = menu->items.count;
-    uint32_t filtered_item_count = menu->filtered.count;
+    uint32_t filtered_item_count = (menu->filter ? menu->filtered.count : total_item_count);
 
     cairo_set_source_rgba(cairo->cr, 0, 0, 0, 0);
     cairo_rectangle(cairo->cr, 0, 0, width, height);

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -480,12 +480,14 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
             paint.box = (struct box){ 1, 2, vpadding, -vpadding, 0, height };
             bm_cairo_draw_line(cairo, &paint, &result, ">");
         }
-        char counter[128];
-        snprintf(counter, sizeof(counter), "[%u/%u]", filtered_item_count, total_item_count);
-        bm_pango_get_text_extents(cairo, &paint, &result, "%s", counter);
-        paint.pos = (struct pos){ width/cairo->scale - result.x_advance - 10, vpadding + border_size };
-        paint.box = (struct box){ 1, 2, vpadding, -vpadding, 0, height };
-        bm_cairo_draw_line(cairo, &paint, &result, "%s", counter);
+        if (menu->counter) {
+            char counter[128];
+            snprintf(counter, sizeof(counter), "[%u/%u]", filtered_item_count, total_item_count);
+            bm_pango_get_text_extents(cairo, &paint, &result, "%s", counter);
+            paint.pos = (struct pos){ width/cairo->scale - result.x_advance - 10, vpadding + border_size };
+            paint.box = (struct box){ 1, 2, vpadding, -vpadding, 0, height };
+            bm_cairo_draw_line(cairo, &paint, &result, "%s", counter);
+        }
     }
 
     // Draw borders

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -480,14 +480,16 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
             paint.box = (struct box){ 1, 2, vpadding, -vpadding, 0, height };
             bm_cairo_draw_line(cairo, &paint, &result, ">");
         }
-        if (menu->counter) {
-            char counter[128];
-            snprintf(counter, sizeof(counter), "[%u/%u]", filtered_item_count, total_item_count);
-            bm_pango_get_text_extents(cairo, &paint, &result, "%s", counter);
-            paint.pos = (struct pos){ width/cairo->scale - result.x_advance - 10, vpadding + border_size };
-            paint.box = (struct box){ 1, 2, vpadding, -vpadding, 0, height };
-            bm_cairo_draw_line(cairo, &paint, &result, "%s", counter);
-        }
+        
+    }
+
+    if (menu->counter) {
+        char counter[128];
+        snprintf(counter, sizeof(counter), "[%u/%u]", filtered_item_count, total_item_count);
+        bm_pango_get_text_extents(cairo, &paint, &result, "%s", counter);
+        paint.pos = (struct pos){ width/cairo->scale - result.x_advance - 10, vpadding + border_size };
+        paint.box = (struct box){ 1, 2, vpadding, -vpadding, 0, height };
+        bm_cairo_draw_line(cairo, &paint, &result, "%s", counter);
     }
 
     // Draw borders


### PR DESCRIPTION
Add a match/page counter to the right side of the bar. I could add an option to disable this, but it shouldn't be required due to how minimal it is. Example: If there are 12 items showing on the bar and a total of 220 items in the system, the bar would show "[12/220]"

~~I forgot to sync my fork with the main branch before adding the counter commits, so for some reason, there are merge conflicts with the main branch, that I couldn't figure out how to fix.~~ Fixed this, I'm not very smart. Ready to merge.

Closes #204 