### PR TITLE
Fix Makefile to support submodule setups

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -33,7 +33,8 @@ wayland: bemenu-renderer-wayland.so
 
 # support non git builds
 .git/index:
-	mkdir -p .git
+	[ -f .git ] && exit; \
+	mkdir -p .git; \
 	touch .git/index
 
 %.a:


### PR DESCRIPTION
If you clone the repository as a submodule, `.git` is a symlink, not a directory, so `make` would fail.