### PR TITLE
ESC have no effect under Wayland while enabled Vim binding

### DIFF
--- a/lib/vim.c
+++ b/lib/vim.c
@@ -212,7 +212,7 @@ enum bm_vim_code bm_vim_key_press(struct bm_menu *menu, enum bm_key key, uint32_
         if(menu->vim_last_key == 0) return vim_on_first_key(menu, unicode, item_count, items_displayed);
         else return vim_on_second_key(menu, unicode, item_count, items_displayed);
     } else if(menu->vim_mode == 'i'){
-        if(key == BM_KEY_ESCAPE && unicode == 0){
+        if(key == BM_KEY_ESCAPE && (unicode == 0 || unicode == 27)){
             menu->vim_mode = 'n';
             return BM_VIM_CONSUME;
         }


### PR DESCRIPTION
Hi all,
Sorry for my bad English.
I'm runned bemenu under Sway. then I saw ESC can not been captured when I enabled Vim binding, menu will exit directly after ESC pressed.
I have tested key respond in the code. got the unicode is not zero when ESC been presssed, the actual value is ASCII code of ESC (27).
So I try to fix it.
I have tested this patch. it worked fine under AwesomeWM(X11), console(curses) and Sway.