### PR TITLE
Add option to exit bemenu using esc in vim binds normal mode

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -185,6 +185,7 @@ usage(FILE *out, const char *name)
           " --fixed-height        prevent the display from changing height on filter.\n"
           " --scrollbar           display scrollbar. (none (default), always, autohide)\n"
           " --counter             display a matched/total items counter. (none (default), always)\n"
+          " -e, --vim-esc-exits   exit bemenu when pressing escape in normal mode for vim bindings\n"
           " --accept-single       immediately return if there is only one item.\n"
           " --ifne                only display menu if there are items.\n"
           " --fork                always fork. (bemenu-run)\n"
@@ -275,6 +276,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
         { "fixed-height", no_argument,       0, 0x090 },
         { "scrollbar",    required_argument, 0, 0x100 },
         { "counter",      required_argument, 0, 0x10a },
+        { "vim-esc-exits",no_argument,       0, 'e' },
         { "accept-single",no_argument,       0, 0x11a },
         { "ifne",         no_argument,       0, 0x117 },
         { "fork",         no_argument,       0, 0x118 },
@@ -371,6 +373,9 @@ do_getopt(struct client *client, int *argc, char **argv[])
                 break;
             case 0x10a:
                 client->counter = (!strcmp(optarg, "always"));
+                break;
+            case 'e':
+                client->vim_esc_exits = true;
                 break;
             case 0x11a:
                 client->accept_single = true;
@@ -555,6 +560,7 @@ menu_with_options(struct client *client)
     bm_menu_set_fixed_height(menu, client->fixed_height);
     bm_menu_set_scrollbar(menu, client->scrollbar);
     bm_menu_set_counter(menu, client->counter);
+    bm_menu_set_vim_esc_exits(menu, client->vim_esc_exits);
     bm_menu_set_panel_overlap(menu, !client->no_overlap);
     bm_menu_set_spacing(menu, !client->no_spacing);
     bm_menu_set_password(menu, client->password);

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -29,6 +29,7 @@ struct client {
     bool wrap;
     bool fixed_height; 
     bool counter;
+    bool vim_esc_exits; 
     bool accept_single;
     bool ifne;
     bool no_overlap;

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -734,6 +734,24 @@ BM_PUBLIC void bm_menu_set_counter(struct bm_menu *menu, bool mode);
 BM_PUBLIC bool bm_menu_get_counter(struct bm_menu *menu);
 
 /**
+ * Set vim escape exit mode of the bar.
+ *
+ * @param menu bm_menu to set the vim escape exit mode for.
+ * @param mode to be set.
+ */
+
+BM_PUBLIC void bm_menu_set_vim_esc_exits(struct bm_menu *menu, bool mode);
+
+/**
+ * Get the vim escape exit mode of the bar.
+ *
+ * @param menu bm_menu to get the vim escape exit mode from.
+ * @param mode current vim escape exit mode
+ */
+
+BM_PUBLIC bool bm_menu_get_vim_esc_exits(struct bm_menu *menu);
+
+/**
  * Set the vertical alignment of the bar.
  *
  * @param menu bm_menu to set alignment for.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -363,6 +363,11 @@ struct bm_menu {
     enum bm_scrollbar_mode scrollbar;
 
     /**
+     * Current vim escape exit mode.
+     */
+    bool vim_esc_exits; 
+
+    /**
      * Current counter display mode.
      */
     bool counter;

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -459,6 +459,18 @@ bm_menu_get_scrollbar(struct bm_menu *menu)
 }
 
 void
+bm_menu_set_vim_esc_exits(struct bm_menu *menu, bool mode)
+{
+    menu->vim_esc_exits = mode;
+}
+
+bool
+bm_menu_get_vim_esc_exits(struct bm_menu *menu)
+{
+    return menu->vim_esc_exits;
+}
+
+void
 bm_menu_set_counter(struct bm_menu *menu, bool mode)
 {
     menu->counter = mode;

--- a/lib/vim.c
+++ b/lib/vim.c
@@ -206,7 +206,11 @@ enum bm_vim_code bm_vim_key_press(struct bm_menu *menu, enum bm_key key, uint32_
     if(key == BM_KEY_ESCAPE && unicode == 99) return BM_VIM_EXIT;
 
     if(menu->vim_mode == 'n'){
-        if(key == BM_KEY_ESCAPE) return BM_VIM_CONSUME;
+        if(key == BM_KEY_ESCAPE){
+            if(menu->vim_esc_exits) return BM_VIM_EXIT;
+            return BM_VIM_CONSUME;
+        }
+
         if(unicode == 0 || unicode > 128) return BM_VIM_IGNORE;
 
         if(menu->vim_last_key == 0) return vim_on_first_key(menu, unicode, item_count, items_displayed);

--- a/man/bemenu.1.scd.in
+++ b/man/bemenu.1.scd.in
@@ -102,6 +102,9 @@ list of executables under PATH and the selected items are executed.
 :  Only display a scrollbar when the number of items exceeds the number
    of lines.
 
+*-e, --vim-esc-exits*
+	Exit bemenu when pressing escape in normal mode for vim bindings.
+
 ## Backend options
 
 These options are only available on backends specified in the parentheses:


### PR DESCRIPTION
Currently, if I want to close bemenu when using vim bindings, I have to press escape + q
It is more convenient to be able to exit bemenu by pressing esc twice (once to get into normal mode, another time to exit)