### PR TITLE
Single instance mode(Addresses #324)

### DIFF
--- a/client/common/common.h
+++ b/client/common/common.h
@@ -33,6 +33,7 @@ struct client {
     bool accept_single;
     bool auto_select;
     bool ifne;
+    bool single_instance;
     bool no_overlap;
     bool no_spacing;
     bool no_cursor;

--- a/man/bemenu.1.scd.in
+++ b/man/bemenu.1.scd.in
@@ -92,6 +92,9 @@ list of executables under PATH and the selected items are executed.
 *--ifne*
 	Only display menu if there are items.
 
+*--single-instance*
+	Force a single menu instance.
+
 *--no-exec*
 	Print the selected items to standard output instead of executing them.
 


### PR DESCRIPTION
Multiple instances of bemenu running at once can freeze/not grab the keyboard once the first instance is closed. This PR kills other bemenu instances when the most recent instance grabs the keyboard, as multiple instances are most likely accidental(need to spam the hotkey or similar, as described by [issue #342](https://github.com/Cloudef/bemenu/issues/342)) and not helped by bemenu's design.

This can be disabled and reverted back to old behavior via the "--multi-instance-mode" flag.

Closes [issue #342](https://github.com/Cloudef/bemenu/issues/342).