### PR TITLE
Password flag parameters with indicator option(Addresses #221)

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -176,7 +176,7 @@ usage(FILE *out, const char *name)
           " -p, --prompt          defines the prompt text to be displayed.\n"
           " -P, --prefix          text to show before highlighted item.\n"
           " -I, --index           select item at index automatically.\n"
-          " -x, --password        hide input.\n"
+          " -x, --password        display/hide/replace input. (none (default), hide, indicator)\n"
           " -s, --no-spacing      disable the title spacing on entries.\n"
           " -C, --no-cursor       ignore cursor events.\n"
           " -T, --no-touch        ignore touch events.\n"
@@ -273,7 +273,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
         { "prompt",       required_argument, 0, 'p' },
         { "index",        required_argument, 0, 'I' },
         { "prefix",       required_argument, 0, 'P' },
-        { "password",     no_argument,       0, 'x' },
+        { "password",     required_argument, 0, 'x' },
         { "fixed-height", no_argument,       0, 0x090 },
         { "scrollbar",    required_argument, 0, 0x100 },
         { "counter",      required_argument, 0, 0x10a },
@@ -332,9 +332,9 @@ do_getopt(struct client *client, int *argc, char **argv[])
     for (optind = 0;;) {
         int32_t opt;
 
-        if ((opt = getopt_long(*argc, *argv, "hviwxcl:I:p:P:I:bfF:m:H:M:W:B:R:nsCTK", opts, NULL)) < 0)
+        if ((opt = getopt_long(*argc, *argv, "hviwcl:I:p:P:I:x:bfF:m:H:M:W:B:R:nsCTK", opts, NULL)) < 0)
             break;
-
+        
         switch (opt) {
             case 'h':
                 usage(stdout, *argv[0]);
@@ -342,7 +342,6 @@ do_getopt(struct client *client, int *argc, char **argv[])
             case 'v':
                 version(*argv[0]);
                 break;
-
             case 'i':
                 client->filter_mode = BM_FILTER_MODE_DMENU_CASE_INSENSITIVE;
                 break;
@@ -395,9 +394,8 @@ do_getopt(struct client *client, int *argc, char **argv[])
                 client->no_exec = true;
                 break;
             case 'x':
-                client->password = true;
+                client->password = (!strcmp(optarg, "none") ? BM_PASSWORD_NONE : (!strcmp(optarg, "hide") ? BM_PASSWORD_HIDE : (!strcmp(optarg, "indicator") ? BM_PASSWORD_INDICATOR : BM_PASSWORD_NONE)));
                 break;
-
             case 'b':
                 client->bottom = true;
                 break;

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -40,7 +40,7 @@ struct client {
     bool no_keyboard;
     bool force_fork, fork;
     bool no_exec;
-    bool password;
+    enum bm_password_mode password;
     enum bm_key_binding key_binding;
     char *monitor_name;
 };

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -188,6 +188,19 @@ enum bm_scrollbar_mode {
 };
 
 /**
+ * Password display mode constants for bm_menu instance filter text.
+ *
+ * - @link ::bm_password_mode BM_PASSWORD_NONE @endlink means that filter text displays what the user inputs(default behavior).
+ * - @link ::bm_password_mode BM_PASSWORD_HIDE @endlink means that filter text is not displayed at all.
+ * - @link ::bm_password_mode BM_PASSWORD_INDICATOR @endlink means that filter text is replaced with asterisks.
+ */
+enum bm_password_mode {
+    BM_PASSWORD_NONE,
+    BM_PASSWORD_HIDE,
+    BM_PASSWORD_INDICATOR,
+};
+
+/**
  * Result constants for the menu run functions.
  *
  * - @link ::bm_run_result BM_RUN_RESULT_RUNNING @endlink means that menu is running and thus should be still renderer && ran.
@@ -846,12 +859,12 @@ BM_PUBLIC bool bm_menu_is_keyboard_grabbed(struct bm_menu *menu);
 BM_PUBLIC void bm_menu_set_panel_overlap(struct bm_menu *menu, bool overlap);
 
 /**
- * Replace input with asterisks.
+ * Set current password mode.
  *
  * @param menu bm_menu instance to set password mode for.
- * @param password true for password mode, false for deafault behavior.
+ * @param password BM_PASSWORD_NONE for default behavior(display what user inputs), BM_PASSWORD_HIDE for no filter text to be displayed, BM_PASSWORD_INDICATOR to replace input with asterisks.
  */
-BM_PUBLIC void bm_menu_set_password(struct bm_menu *menu, bool password);
+BM_PUBLIC void bm_menu_set_password(struct bm_menu *menu, enum bm_password_mode mode);
 
 /**
  * Space entries with title.
@@ -865,9 +878,9 @@ BM_PUBLIC void bm_menu_set_spacing(struct bm_menu *menu, bool spacing);
  * Is password mode activated and input hidden?
  *
  * @param menu bm_menu instance where to get password mode from.
- * @return true if password mode, false otherwise.
+ * @return BM_PASSWORD_NONE is default behavior(display what user inputs), BM_PASSWORD_HIDE is no filter text is being displayed, BM_PASSWORD_INDICATOR is replacing input with asterisks.
  */
-BM_PUBLIC bool bm_menu_get_password(struct bm_menu *menu);
+BM_PUBLIC enum bm_password_mode bm_menu_get_password(struct bm_menu *menu);
 
 
 /**

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -413,9 +413,9 @@ struct bm_menu {
     bool overlap;
 
     /**
-     * Should the input be hidden
+     * Should the input be displayed/hidden/replaced
      */
-    bool password;
+    enum bm_password_mode password;
 
     /**
      * Should the entry should follow the title spacing

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -616,17 +616,17 @@ bm_menu_set_spacing(struct bm_menu *menu, bool spacing)
 }
 
 void
-bm_menu_set_password(struct bm_menu *menu, bool password)
+bm_menu_set_password(struct bm_menu *menu, enum bm_password_mode mode)
 {
     assert(menu);
 
-    if (menu->password == password)
+    if (menu->password == mode)
         return;
 
-    menu->password = password;
+    menu->password = mode;
 }
 
-bool
+enum bm_password_mode
 bm_menu_get_password(struct bm_menu *menu)
 {
     assert(menu);

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -331,9 +331,15 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, const s
     paint.box = (struct box){ (menu->title ? 2 : 4), 0, vpadding, -vpadding, width - paint.pos.x, height };
 
     const char *filter_text = (menu->filter ? menu->filter : "");
-    if (menu->password) {
+    if (menu->password == BM_PASSWORD_HIDE) {
         bm_cairo_draw_line_str(cairo, &paint, &result, "");
-    } else {
+    } else if (menu->password == BM_PASSWORD_INDICATOR) {
+        char asterisk_print[1024] = "";
+        
+        for (int i = 0; i < (int)(strlen(filter_text)); ++i) asterisk_print[i] = '*';
+        
+        bm_cairo_draw_line(cairo, &paint, &result, "%s", asterisk_print);
+    } else if (menu->password == BM_PASSWORD_NONE) {
         bm_cairo_draw_line(cairo, &paint, &result, "%s", filter_text);
     }
 

--- a/man/bemenu.1.scd.in
+++ b/man/bemenu.1.scd.in
@@ -70,8 +70,14 @@ list of executables under PATH and the selected items are executed.
 *-w, --wrap*
 	Advancing past the end of the list returns you to the start.
 
-*-x, --password*
-	Hide filter text.
+*-x, --password* _none_|_hide_|_indicator_
+	Specify how the filter text should be displayed:
+[[ *none*
+:< Display the input (the default).
+|  *hide*
+:  Do not display any input.
+|  *indicator*
+:  Replace input with asterisks.
 
 *--fixed-height*
 	Prevent the display from changing height on filter.


### PR DESCRIPTION
Add parameters to the password flag, as well as add an "indicator" option to this flag to replace the input with asterisks, instead of hiding the input or displaying it normally.

Closes #221 