### PR TITLE
Update help/usage to add cursor background and foreground colors(Addresses #361).

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -221,6 +221,8 @@ usage(FILE *out, const char *name)
           " --tf                  defines the title foreground color. (wx)\n"
           " --fb                  defines the filter background color. (wx)\n"
           " --ff                  defines the filter foreground color. (wx)\n"
+          " --cb                  defines the cursor background color. (wx)\n"
+          " --cf                  defines the cursor foreground color. (wx)\n"
           " --nb                  defines the normal background color. (wx)\n"
           " --nf                  defines the normal foreground color. (wx)\n"
           " --hb                  defines the highlighted background color. (wx)\n"


### PR DESCRIPTION
Cursor background and foreground colors were previously documented in the man page, but not in help/usage.

Closes #361 