### PR TITLE
Upwards list support(Addresses #328, X11/Wayland/Cairo)

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -443,10 +443,10 @@ do_getopt(struct client *client, int *argc, char **argv[])
                 client->width_factor = strtof(optarg, NULL);
                 break;
             case 'B':
-                client->border_size = strtol(optarg, NULL, 10);
+                client->border_size = strtod(optarg, NULL);
                 break;
             case 'R':
-                client->border_radius = strtol(optarg, NULL, 10);
+                client->border_radius = strtod(optarg, NULL);
                 break;
             case 0x120:
                 client->cursor_height = strtol(optarg, NULL, 10);

--- a/client/common/common.c
+++ b/client/common/common.c
@@ -174,7 +174,7 @@ usage(FILE *out, const char *name)
           " -i, --ignorecase      match items case insensitively.\n"
           " -F, --filter          filter entries for a given string before showing the menu.\n"
           " -w, --wrap            wraps cursor selection.\n"
-          " -l, --list            list items vertically with the given number of lines.\n"
+          " -l, --list            list items vertically down or up with the given number of lines(number of lines down/up). (down (default), up)\n"
           " -p, --prompt          defines the prompt text to be displayed.\n"
           " -P, --prefix          text to show before highlighted item.\n"
           " -I, --index           select item at index automatically.\n"
@@ -358,8 +358,12 @@ do_getopt(struct client *client, int *argc, char **argv[])
                 client->wrap = true;
                 break;
             case 'l':
-                client->lines = strtol(optarg, NULL, 10);
+            {
+                char *ptr;
+                client->lines = strtol(optarg, &ptr, 10);
+                client->lines_mode = (!strcmp(ptr + 1, "up") ? BM_LINES_UP : BM_LINES_DOWN);
                 break;
+            }
             case 'c':
                 client->center = true;
                 break;
@@ -566,6 +570,7 @@ menu_with_options(struct client *client)
     bm_menu_set_prefix(menu, client->prefix);
     bm_menu_set_filter_mode(menu, client->filter_mode);
     bm_menu_set_lines(menu, client->lines);
+    bm_menu_set_lines_mode(menu, client->lines_mode);
     bm_menu_set_wrap(menu, client->wrap);
     bm_menu_set_monitor(menu, client->monitor);
     bm_menu_set_monitor_name(menu, client->monitor_name);

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -17,6 +17,7 @@ struct client {
     uint32_t cursor_width;
     uint32_t hpadding;
     uint32_t lines;
+    enum bm_lines_mode lines_mode;
     uint32_t selected;
     uint32_t monitor;
     uint32_t hmargin_size;

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -21,8 +21,8 @@ struct client {
     uint32_t selected;
     uint32_t monitor;
     uint32_t hmargin_size;
-    uint32_t border_size;
-    uint32_t border_radius;
+    double border_size;
+    double border_radius;
     float width_factor;
     bool bottom;
     bool center;

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -201,6 +201,17 @@ enum bm_password_mode {
 };
 
 /**
+ * Vertical menu display mode constants for bm_menu instance lines.
+ *
+ * - @link ::bm_lines_mode BM_LINES_DOWN @endlink means that the vertical menu lines will go downwards.
+ * - @link ::bm_lines_mode BM_LINES_UP @endlink means that the vertical menu lines will go upwards
+ */
+enum bm_lines_mode {
+    BM_LINES_DOWN,
+    BM_LINES_UP,
+};
+
+/**
  * Result constants for the menu run functions.
  *
  * - @link ::bm_run_result BM_RUN_RESULT_RUNNING @endlink means that menu is running and thus should be still renderer && ran.
@@ -505,6 +516,22 @@ BM_PUBLIC void bm_menu_set_lines(struct bm_menu *menu, uint32_t lines);
 BM_PUBLIC uint32_t bm_menu_get_lines(struct bm_menu *menu);
 
 /**
+ * Set the direction in which lines should go after the filter text.
+ *
+ * @param menu bm_menu instance where to set lines direction.
+ * @param mode bm_lines_mode constant.
+ */
+BM_PUBLIC void bm_menu_set_lines_mode(struct bm_menu *menu, enum bm_lines_mode mode);
+
+/**
+ * Get the direction in which lines should go after the filter text.
+ *
+ * @param menu bm_menu instance where to get the lines direction.
+ * @return bm_lines_mode constant
+ */
+BM_PUBLIC enum bm_lines_mode bm_menu_get_lines_mode(struct bm_menu *menu);
+
+/**
  * Set selection wrapping on/off.
  *
  * @param menu bm_menu instance where to toggle selection wrapping.
@@ -780,6 +807,23 @@ BM_PUBLIC void bm_menu_set_align(struct bm_menu *menu, enum bm_align align);
  */
 
 BM_PUBLIC enum bm_align bm_menu_get_align(struct bm_menu *menu);
+
+/**
+ * Set the vertical/y offset of the window.
+ *
+ * @param menu bm_menu to set offset for.
+ * @param y_offset offset to set.
+ */
+BM_PUBLIC void bm_menu_set_y_offset(struct bm_menu *menu, int32_t y_offset);
+
+/**
+ * Get the vertical/y offset of the window.
+ *
+ * @param menu bm_menu to get y offset from.
+ * @return y offset of the menu.
+ */
+
+BM_PUBLIC int32_t bm_menu_get_y_offset(struct bm_menu *menu);
 
 /**
  * Set the horizontal margin and the relative width factor of the bar.

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -670,10 +670,9 @@ BM_PUBLIC uint32_t bm_menu_get_width(struct bm_menu *menu);
  * Set the size of the border for the bar
  *
  * @param menu bm_menu to get border size from.
- * @return border size of the menu.
  */
 
-BM_PUBLIC void bm_menu_set_border_size(struct bm_menu* menu, uint32_t border_size);
+BM_PUBLIC void bm_menu_set_border_size(struct bm_menu* menu, double border_size);
 
 /**
  * Get the size of the border for the bar
@@ -682,16 +681,15 @@ BM_PUBLIC void bm_menu_set_border_size(struct bm_menu* menu, uint32_t border_siz
  * @return border size of the menu.
  */
 
-BM_PUBLIC uint32_t bm_menu_get_border_size(struct bm_menu* menu);
+BM_PUBLIC double bm_menu_get_border_size(struct bm_menu* menu);
 
 /**
  * Set the radius of the border for the bar
  *
  * @param menu bm_menu to get border radius from.
- * @return border radius of the menu.
  */
 
-BM_PUBLIC void bm_menu_set_border_radius(struct bm_menu* menu, uint32_t border_radius);
+BM_PUBLIC void bm_menu_set_border_radius(struct bm_menu* menu, double border_radius);
 
 /**
  * Get the size of the border for the bar
@@ -700,7 +698,7 @@ BM_PUBLIC void bm_menu_set_border_radius(struct bm_menu* menu, uint32_t border_r
  * @return border radius of the menu.
  */
 
-BM_PUBLIC uint32_t bm_menu_get_border_radius(struct bm_menu* menu);
+BM_PUBLIC double bm_menu_get_border_radius(struct bm_menu* menu);
 
 /**
  * Set a hexadecimal color for element.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -111,6 +111,11 @@ struct render_api {
     void (*set_align)(const struct bm_menu *menu, enum bm_align align);
 
     /**
+     * Set vertical/y offset of the window.
+     */
+    void (*set_y_offset)(const struct bm_menu *menu, int32_t y_offset);
+
+    /**
      * Set horizontal margin and relative width factor.
      */
     void (*set_width)(const struct bm_menu *menu, uint32_t margin, float factor);
@@ -338,6 +343,11 @@ struct bm_menu {
     uint32_t lines;
 
     /**
+     * Current vertical line mode.
+     */
+    enum bm_lines_mode lines_mode;
+
+    /**
      * Current monitor.
      */
     int32_t monitor;
@@ -381,6 +391,11 @@ struct bm_menu {
      * Vertical alignment.
      */
     enum bm_align align;
+
+    /**
+     * Vertical/y offset.
+     */
+    int32_t y_offset;
 
     /**
      * Horizontal margin.

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -410,12 +410,12 @@ struct bm_menu {
     /**
      * Border size
      */
-    uint32_t border_size;
+    double border_size;
 
     /**
      * Border radius
      */
-    uint32_t border_radius;
+    double border_radius;
 
     /**
      * Is menu grabbed?

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -361,13 +361,13 @@ bm_menu_get_hpadding(struct bm_menu *menu)
 }
 
 void
-bm_menu_set_border_size(struct bm_menu* menu, uint32_t border_size)
+bm_menu_set_border_size(struct bm_menu* menu, double border_size)
 {
     assert(menu);
     menu->border_size = border_size;
 }
 
-uint32_t
+double
 bm_menu_get_border_size(struct bm_menu* menu)
 {
     assert(menu);
@@ -375,13 +375,13 @@ bm_menu_get_border_size(struct bm_menu* menu)
 }
 
 void
-bm_menu_set_border_radius(struct bm_menu* menu, uint32_t border_radius)
+bm_menu_set_border_radius(struct bm_menu* menu, double border_radius)
 {
     assert(menu);
     menu->border_radius = border_radius;
 }
 
-uint32_t
+double
 bm_menu_get_border_radius(struct bm_menu* menu)
 {
     assert(menu);

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -232,6 +232,20 @@ bm_menu_get_lines(struct bm_menu *menu)
 }
 
 void
+bm_menu_set_lines_mode(struct bm_menu *menu, enum bm_lines_mode mode)
+{
+    assert(menu);
+    menu->lines_mode = mode;
+}
+
+enum bm_lines_mode
+bm_menu_get_lines_mode(struct bm_menu *menu)
+{
+    assert(menu);
+    return menu->lines_mode;
+}
+
+void
 bm_menu_set_wrap(struct bm_menu *menu, bool wrap)
 {
     assert(menu);
@@ -501,6 +515,27 @@ bm_menu_get_align(struct bm_menu *menu)
 {
     assert(menu);
     return menu->align;
+}
+
+void
+bm_menu_set_y_offset(struct bm_menu *menu, int32_t y_offset)
+{
+    assert(menu);
+
+    if(menu->y_offset == y_offset)
+        return;
+
+    menu->y_offset = y_offset;
+
+    if (menu->renderer->api.set_y_offset)
+        menu->renderer->api.set_y_offset(menu, y_offset);
+}
+
+int32_t
+bm_menu_get_y_offset(struct bm_menu *menu)
+{
+    assert(menu);
+    return menu->y_offset;
 }
 
 void
@@ -1041,11 +1076,11 @@ bm_menu_run_with_key(struct bm_menu *menu, enum bm_key key, uint32_t unicode)
             break;
 
         case BM_KEY_UP:
-            menu_prev(menu, count, menu->wrap);
+            (menu->lines_mode == BM_LINES_UP ? menu_next(menu, count, menu->wrap) : menu_prev(menu, count, menu->wrap));
             break;
 
         case BM_KEY_DOWN:
-            menu_next(menu, count, menu->wrap);
+            (menu->lines_mode == BM_LINES_UP ? menu_prev(menu, count, menu->wrap) : menu_next(menu, count, menu->wrap));
             break;
 
         case BM_KEY_PAGE_UP:

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -314,10 +314,7 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, struct 
     uint32_t page_length = 0;
 
     if (menu->lines_mode == BM_LINES_UP && !menu->fixed_height) {
-        struct cairo_result dummy_result;
-        bm_cairo_draw_line_str(cairo, &paint, &dummy_result, "");
-
-        int32_t new_y_offset = (count < lines ? (lines - count) * result.height : 0);
+        int32_t new_y_offset = (count < lines ? (lines - count) * height : 0);
         bm_menu_set_y_offset(menu, new_y_offset);
     }
 
@@ -330,7 +327,7 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, struct 
         enum bm_color title_bg = (menu->lines_mode == BM_LINES_UP ? BM_COLOR_ITEM_BG : BM_COLOR_TITLE_BG);
         bm_cairo_color_from_menu_color(menu, title_fg, &paint.fg);
         bm_cairo_color_from_menu_color(menu, title_bg, &paint.bg);
-        paint.pos = (struct pos){ result.x_advance + border_size + 4, vpadding + border_size };
+        paint.pos = (struct pos){ border_size + 4, vpadding + border_size };
         paint.box = (struct box){ 4, 16, vpadding, -vpadding, 0, height };
         bm_cairo_draw_line(cairo, &paint, &result, "%s", menu->title);
         title_x = result.x_advance;
@@ -528,14 +525,12 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, struct 
         
     }
 
-    struct cairo_paint pre_up_drawing = paint;  // Some behavior may depend on the previous paint.
-
     if (menu->lines_mode == BM_LINES_UP) {
         if (menu->title) {
             bm_cairo_color_from_menu_color(menu, BM_COLOR_TITLE_FG, &paint.fg);
             bm_cairo_color_from_menu_color(menu, BM_COLOR_TITLE_BG, &paint.bg);
         
-            paint.pos = (struct pos){ border_size, posy + border_size };
+            paint.pos = (struct pos){ border_size + 4, posy + vpadding + border_size };
             paint.box = (struct box){ 4, 16, vpadding, -vpadding, 0, height };
             bm_cairo_draw_line(cairo, &paint, &result, "%s", menu->title);
         }
@@ -570,8 +565,6 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, struct 
         posy += (spacing_y ? spacing_y : result.height);
         out_result->height = posy;
         out_result->displayed++;
-
-        paint = pre_up_drawing;
     }
 
     if (menu->counter) {

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -14,7 +14,7 @@
 static int efd;
 
 static void
-render_windows_if_pending(const struct bm_menu *menu, struct wayland *wayland) {
+render_windows_if_pending(struct bm_menu *menu, struct wayland *wayland) {
     struct window *window;
     wl_list_for_each(window, &wayland->windows, link) {
         if (window->render_pending)

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -398,6 +398,18 @@ set_align(const struct bm_menu *menu, enum bm_align align)
 }
 
 static void
+set_y_offset(const struct bm_menu *menu, int32_t y_offset)
+{
+    struct wayland *wayland = menu->renderer->internal;
+    assert(wayland);
+
+    struct window *window;
+    wl_list_for_each(window, &wayland->windows, link) {
+        bm_wl_window_set_y_offset(window, wayland->display, y_offset);
+    }
+}
+
+static void
 grab_keyboard(const struct bm_menu *menu, bool grab)
 {
     struct wayland *wayland = menu->renderer->internal;
@@ -597,6 +609,7 @@ register_renderer(struct render_api *api)
     api->release_touch = release_touch;
     api->render = render;
     api->set_align = set_align;
+    api->set_y_offset = set_y_offset;
     api->set_width = set_width;
     api->grab_keyboard = grab_keyboard;
     api->set_overlap = set_overlap;

--- a/lib/renderers/wayland/wayland.h
+++ b/lib/renderers/wayland/wayland.h
@@ -131,7 +131,7 @@ struct window {
     bool render_pending;
 
     struct {
-        void (*render)(struct cairo *cairo, uint32_t width, uint32_t max_height, const struct bm_menu *menu, struct cairo_paint_result *result);
+        void (*render)(struct cairo *cairo, uint32_t width, uint32_t max_height, struct bm_menu *menu, struct cairo_paint_result *result);
     } notify;
 };
 
@@ -167,7 +167,7 @@ void bm_wl_repeat(struct wayland *wayland);
 bool bm_wl_registry_register(struct wayland *wayland);
 void bm_wl_registry_destroy(struct wayland *wayland);
 void bm_wl_window_schedule_render(struct window *window);
-void bm_wl_window_render(struct window *window, struct wl_display *display, const struct bm_menu *menu);
+void bm_wl_window_render(struct window *window, struct wl_display *display, struct bm_menu *menu);
 void bm_wl_window_set_width(struct window *window, struct wl_display *display, uint32_t margin, float factor);
 void bm_wl_window_set_align(struct window *window, struct wl_display *display, enum bm_align align);
 void bm_wl_window_grab_keyboard(struct window *window, struct wl_display *display, bool grab);

--- a/lib/renderers/wayland/wayland.h
+++ b/lib/renderers/wayland/wayland.h
@@ -127,6 +127,7 @@ struct window {
     uint32_t displayed;
     struct wl_list link;
     enum bm_align align;
+    int32_t y_offset;
     uint32_t align_anchor;
     bool render_pending;
 
@@ -170,6 +171,7 @@ void bm_wl_window_schedule_render(struct window *window);
 void bm_wl_window_render(struct window *window, struct wl_display *display, struct bm_menu *menu);
 void bm_wl_window_set_width(struct window *window, struct wl_display *display, uint32_t margin, float factor);
 void bm_wl_window_set_align(struct window *window, struct wl_display *display, enum bm_align align);
+void bm_wl_window_set_y_offset(struct window *window, struct wl_display *display, int32_t y_offset);
 void bm_wl_window_grab_keyboard(struct window *window, struct wl_display *display, bool grab);
 void bm_wl_window_set_overlap(struct window *window, struct wl_display *display, bool overlap);
 bool bm_wl_window_create(struct window *window, struct wl_display *display, struct wl_shm *shm, struct wl_output *output, struct zwlr_layer_shell_v1 *layer_shell, struct wl_surface *surface);

--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -353,6 +353,19 @@ bm_wl_window_set_align(struct window *window, struct wl_display *display, enum b
 }
 
 void
+bm_wl_window_set_y_offset(struct window *window, struct wl_display *display, int32_t y_offset)
+{
+    if(window->y_offset == y_offset)
+        return;
+
+    window->y_offset = y_offset;
+
+    zwlr_layer_surface_v1_set_margin(window->layer_surface, window->y_offset, 0, 0, 0);
+    wl_surface_commit(window->surface);
+    wl_display_roundtrip(display);
+}
+
+void
 bm_wl_window_grab_keyboard(struct window *window, struct wl_display *display, bool grab)
 {
     zwlr_layer_surface_v1_set_keyboard_interactivity(window->layer_surface, grab);

--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -235,7 +235,7 @@ bm_wl_window_schedule_render(struct window *window)
 }
 
 void
-bm_wl_window_render(struct window *window, struct wl_display *display, const struct bm_menu *menu)
+bm_wl_window_render(struct window *window, struct wl_display *display, struct bm_menu *menu)
 {
     assert(window && menu);
     struct buffer *buffer;

--- a/lib/renderers/x11/window.c
+++ b/lib/renderers/x11/window.c
@@ -251,7 +251,6 @@ bm_x11_window_set_y_offset(struct window *window, int32_t y_offset)
         return;
 
     window->y_offset = y_offset;
-    XMoveWindow(window->display, window->drawable, window->x, window->y + window->y_offset);
 }
 
 void

--- a/lib/renderers/x11/window.c
+++ b/lib/renderers/x11/window.c
@@ -78,7 +78,7 @@ get_window_width(struct window *window)
 }
 
 void
-bm_x11_window_render(struct window *window, const struct bm_menu *menu)
+bm_x11_window_render(struct window *window, struct bm_menu *menu)
 {
     assert(window && menu);
     uint32_t oldw = window->width, oldh = window->height;
@@ -115,7 +115,7 @@ bm_x11_window_render(struct window *window, const struct bm_menu *menu)
                 win_y = window->max_height - window->height;
         }
 
-        XMoveResizeWindow(window->display, window->drawable, window->x, win_y, window->width, window->height);
+        XMoveResizeWindow(window->display, window->drawable, window->x, win_y + window->y_offset, window->width, window->height);
     }
 
     if (buffer->created) {
@@ -230,7 +230,7 @@ bm_x11_window_set_monitor(struct window *window, int32_t monitor)
     }
 
     window->monitor = monitor;
-    XMoveResizeWindow(window->display, window->drawable, window->x, window->y, window->width, window->height);
+    XMoveResizeWindow(window->display, window->drawable, window->x, window->y + window->y_offset, window->width, window->height);
     XFlush(window->display);
 }
 
@@ -242,6 +242,16 @@ bm_x11_window_set_align(struct window *window, enum bm_align align)
 
     window->align = align;
     bm_x11_window_set_monitor(window, window->monitor);
+}
+
+void
+bm_x11_window_set_y_offset(struct window *window, int32_t y_offset)
+{
+    if(window->y_offset == y_offset)
+        return;
+
+    window->y_offset = y_offset;
+    XMoveWindow(window->display, window->drawable, window->x, window->y + window->y_offset);
 }
 
 void

--- a/lib/renderers/x11/x11.c
+++ b/lib/renderers/x11/x11.c
@@ -212,6 +212,14 @@ set_align(const struct bm_menu *menu, enum bm_align align)
 }
 
 static void
+set_y_offset(const struct bm_menu *menu, int32_t y_offset)
+{
+    struct x11 *x11 = menu->renderer->internal;
+    assert(x11);
+    bm_x11_window_set_y_offset(&x11->window, y_offset);
+}
+
+static void
 set_width(const struct bm_menu *menu, uint32_t margin, float factor)
 {
     struct x11 *x11 = menu->renderer->internal;
@@ -301,6 +309,7 @@ register_renderer(struct render_api *api)
     api->poll_key = poll_key;
     api->render = render;
     api->set_align = set_align;
+    api->set_y_offset = set_y_offset;
     api->set_width = set_width;
     api->set_monitor = set_monitor;
     api->grab_keyboard = grab_keyboard;

--- a/lib/renderers/x11/x11.h
+++ b/lib/renderers/x11/x11.h
@@ -40,9 +40,10 @@ struct window {
 
     int32_t monitor;
     enum bm_align align;
+    int32_t y_offset;
 
     struct {
-        void (*render)(struct cairo *cairo, uint32_t width, uint32_t max_height, const struct bm_menu *menu, struct cairo_paint_result *result);
+        void (*render)(struct cairo *cairo, uint32_t width, uint32_t max_height, struct bm_menu *menu, struct cairo_paint_result *result);
     } notify;
 };
 
@@ -51,10 +52,11 @@ struct x11 {
     struct window window;
 };
 
-void bm_x11_window_render(struct window *window, const struct bm_menu *menu);
+void bm_x11_window_render(struct window *window, struct bm_menu *menu);
 void bm_x11_window_key_press(struct window *window, XKeyEvent *ev);
 void bm_x11_window_set_monitor(struct window *window, int32_t monitor);
 void bm_x11_window_set_align(struct window *window, enum bm_align align);
+void bm_x11_window_set_y_offset(struct window *window, int32_t y_offset);
 void bm_x11_window_set_width(struct window *window, uint32_t margin, float factor);
 bool bm_x11_window_create(struct window *window, Display *display);
 void bm_x11_window_destroy(struct window *window);

--- a/man/bemenu.1.scd.in
+++ b/man/bemenu.1.scd.in
@@ -48,8 +48,8 @@ list of executables under PATH and the selected items are executed.
 *-K, --no-keyboard*
 	Disable all keyboard events.
 
-*-l, --list* <_number_>
-	List items vertically with the given _number_ of lines.
+*-l, --list* "<_number_> _down_|_up_"
+	List items vertically _down_ or _up_ with the given _number_ of lines.
 
 *-P, --prefix* <_prefix_>
 	Display _prefix_ before the highlighted item in a vertical list.


### PR DESCRIPTION
Implement upwards list parameters, documentation, etc. as well as refactor some related Cairo code.

This is now fully implemented in X11, but Wayland will be implemented soon due to the large amount of the changes being related to Cairo, instead of X11. For now, this pull request will be a draft until I add support for Wayland and (maybe)Curses.

Regarding Curses, it is likely that I will try and merge this pull request with Wayland and X11 support, and then start work on catching Curses up to speed feature-wise seperately, as it is missing some features such as fixed-height and similar.

From #328 