### PR TITLE
fix: wayland mmap failed on Sway 1.8.1

### DIFF
--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -517,6 +517,11 @@ recreate_windows(const struct bm_menu *menu, struct wayland *wayland)
     window->hmargin_size = menu->hmargin_size;
     window->width_factor = menu->width_factor;
 
+    // TODO: this should not be necessary, but Sway 1.8.1 does not trigger event
+    // surface.enter before we actually need to render the first frame.
+    window->scale = 1;
+    window->max_height = 640;
+
     struct wl_surface *surface = NULL;
     if (!(surface = wl_compositor_create_surface(wayland->compositor)))
         goto fail;


### PR DESCRIPTION
Sway 1.8.1 does not trigger some event as surface.enter before we are asked to render the first frame. This cause this first frame to be rendered with wrong attributes. (but that is better than crashing)

This is solved with Sway master, precisely with commit:

> 7d2e4a51063ac90f950cb44f141ab391cbcaff5f
>
> layer-shell: enter output before surface is mapped
>
> This sends fractional-scale-v1 events before the first configure
> event. That way clients have all of the metadata they need to render
> the first frame.

To ensure we don't fails rendering the first frame, even if the compositor does not provide metadata in a correct order, we initialize the window structure with default values.