### PR TITLE
Split configuration variables to a `config.h` file. (suckless style)

### DIFF
--- a/client/bemenu-run.c
+++ b/client/bemenu-run.c
@@ -5,13 +5,7 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <assert.h>
-#include "common/common.h"
-
-static struct client client = {
-    .filter_mode = BM_FILTER_MODE_DMENU,
-    .title = "bemenu-run",
-    .monitor = -1,
-};
+#include "../lib/config.h"
 
 struct paths {
    char *path;
@@ -177,14 +171,14 @@ main(int argc, char **argv)
     if (!bm_init())
         return EXIT_FAILURE;
 
-    parse_args(&client, &argc, &argv);
+    parse_args(&default_bmenu_run_client, &argc, &argv);
 
     struct bm_menu *menu;
-    if (!(menu = menu_with_options(&client)))
+    if (!(menu = menu_with_options(&default_bmenu_run_client)))
         return EXIT_FAILURE;
 
     read_items_to_menu_from_path(menu);
-    const enum bm_run_result status = run_menu(&client, menu, item_cb);
+    const enum bm_run_result status = run_menu(&default_bmenu_run_client, menu, item_cb);
     bm_menu_free(menu);
     return (status == BM_RUN_RESULT_SELECTED ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/client/bemenu.c
+++ b/client/bemenu.c
@@ -4,11 +4,6 @@
 #include <assert.h>
 #include "common/common.h"
 
-static struct client client = {
-    .filter_mode = BM_FILTER_MODE_DMENU,
-    .title = "bemenu",
-    .monitor = -1,
-};
 
 static void
 read_items_to_menu_from_stdin(struct bm_menu *menu)
@@ -46,20 +41,23 @@ item_cb(const struct client *client, struct bm_item *item)
     printf("%s\n", (text ? text : ""));
 }
 
+#include "../lib/config.h"
+
 int
 main(int argc, char **argv)
 {
+
     if (!bm_init())
         return EXIT_FAILURE;
 
-    parse_args(&client, &argc, &argv);
+    parse_args(&default_bmenu_client, &argc, &argv);
 
     struct bm_menu *menu;
-    if (!(menu = menu_with_options(&client)))
+    if (!(menu = menu_with_options(&default_bmenu_client)))
         return EXIT_FAILURE;
 
     read_items_to_menu_from_stdin(menu);
-    const enum bm_run_result status = run_menu(&client, menu, item_cb);
+    const enum bm_run_result status = run_menu(&default_bmenu_client, menu, item_cb);
     bm_menu_free(menu);
     switch (status) {
         case BM_RUN_RESULT_SELECTED:

--- a/lib/config.h
+++ b/lib/config.h
@@ -1,3 +1,5 @@
+#include "../client/common/common.h"
+
 /**
  * Default font.
  */
@@ -26,4 +28,22 @@ static const char *default_colors[BM_COLOR_LAST] = {
     "#121212FF", // BM_COLOR_SCROLLBAR_BG
     "#D81860FF", // BM_COLOR_SCROLLBAR_FG
     "#D81860FF", // BM_COLOR_BORDER
+};
+
+/**
+ * Default title/prompt for the bmenu client (Can be changed with `-p` option).
+ */
+static struct client default_bmenu_client = {
+        .filter_mode = BM_FILTER_MODE_DMENU,
+        .title = "bemenu",
+        .monitor = -1,
+};
+
+/**
+ * Default title/prompt for the bmenu-run client (Can be changed with `-p` option).
+ */
+static struct client default_bmenu_run_client = {
+        .filter_mode = BM_FILTER_MODE_DMENU,
+        .title = "bemenu-run",
+        .monitor = -1,
 };

--- a/lib/config.h
+++ b/lib/config.h
@@ -1,0 +1,29 @@
+/**
+ * Default font.
+ */
+static const char *default_font = "monospace 10";
+
+/**
+ * Default hexadecimal colors.
+ */
+static const char *default_colors[BM_COLOR_LAST] = {
+    "#121212FF", // BM_COLOR_TITLE_BG
+    "#D81860FF", // BM_COLOR_TITLE_FG
+    "#121212FF", // BM_COLOR_FILTER_BG
+    "#CACACAFF", // BM_COLOR_FILTER_FG
+    "#121212FF", // BM_COLOR_CURSOR_BG
+    "#CACACAFF", // BM_COLOR_CURSOR_FG
+    "#121212FF", // BM_COLOR_ITEM_BG
+    "#CACACAFF", // BM_COLOR_ITEM_FG
+    "#121212FF", // BM_COLOR_HIGHLIGHTED_BG
+    "#D81860FF", // BM_COLOR_HIGHLIGHTED_FG
+    "#D81860FF", // BM_COLOR_FEEDBACK_BG
+    "#121212FF", // BM_COLOR_FEEDBACK_FG
+    "#121212FF", // BM_COLOR_SELECTED_BG
+    "#D81860FF", // BM_COLOR_SELECTED_FG
+    "#121212FF", // BM_COLOR_ALTERNATE_BG
+    "#CACACAFF", // BM_COLOR_ALTERNATE_FG
+    "#121212FF", // BM_COLOR_SCROLLBAR_BG
+    "#D81860FF", // BM_COLOR_SCROLLBAR_FG
+    "#D81860FF", // BM_COLOR_BORDER
+};

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -8,35 +8,7 @@
 
 #include "vim.h"
 
-/**
- * Default font.
- */
-static const char *default_font = "monospace 10";
-
-/**
- * Default hexadecimal colors.
- */
-static const char *default_colors[BM_COLOR_LAST] = {
-    "#121212FF", // BM_COLOR_TITLE_BG
-    "#D81860FF", // BM_COLOR_TITLE_FG
-    "#121212FF", // BM_COLOR_FILTER_BG
-    "#CACACAFF", // BM_COLOR_FILTER_FG
-    "#121212FF", // BM_COLOR_CURSOR_BG
-    "#CACACAFF", // BM_COLOR_CURSOR_FG
-    "#121212FF", // BM_COLOR_ITEM_BG
-    "#CACACAFF", // BM_COLOR_ITEM_FG
-    "#121212FF", // BM_COLOR_HIGHLIGHTED_BG
-    "#D81860FF", // BM_COLOR_HIGHLIGHTED_FG
-    "#D81860FF", // BM_COLOR_FEEDBACK_BG
-    "#121212FF", // BM_COLOR_FEEDBACK_FG
-    "#121212FF", // BM_COLOR_SELECTED_BG
-    "#D81860FF", // BM_COLOR_SELECTED_FG
-    "#121212FF", // BM_COLOR_ALTERNATE_BG
-    "#CACACAFF", // BM_COLOR_ALTERNATE_FG
-    "#121212FF", // BM_COLOR_SCROLLBAR_BG
-    "#D81860FF", // BM_COLOR_SCROLLBAR_FG
-    "#D81860FF", // BM_COLOR_BORDER
-};
+#include "config.h"
 
 /**
  * Filter function map.


### PR DESCRIPTION
This would allow for a separation between the configuration part and the logic part of bemenu.

Thanks