### PR TITLE
feat: C-b to go left

### DIFF
--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -171,6 +171,9 @@ poll_key(const struct bm_menu *menu, unsigned int *unicode)
         case XKB_KEY_l:
             return (mods & MOD_CTRL ? BM_KEY_LEFT : (mods & MOD_ALT ? BM_KEY_DOWN : BM_KEY_UNICODE));
 
+        case XKB_KEY_b:
+            return (mods & MOD_CTRL ? BM_KEY_LEFT : BM_KEY_UNICODE);
+
         case XKB_KEY_f:
             return (mods & MOD_CTRL ? BM_KEY_RIGHT : BM_KEY_UNICODE);
 

--- a/lib/renderers/x11/x11.c
+++ b/lib/renderers/x11/x11.c
@@ -125,6 +125,9 @@ poll_key(const struct bm_menu *menu, unsigned int *unicode)
         case XK_l:
             return (mods & MOD_CTRL ? BM_KEY_LEFT : (mods & MOD_ALT ? BM_KEY_DOWN : BM_KEY_UNICODE));
 
+        case XK_b:
+            return (mods & MOD_CTRL ? BM_KEY_LEFT : BM_KEY_UNICODE);
+
         case XK_f:
             return (mods & MOD_CTRL ? BM_KEY_RIGHT : BM_KEY_UNICODE);
 

--- a/man/bemenu.1.scd.in
+++ b/man/bemenu.1.scd.in
@@ -271,7 +271,7 @@ In the following examples, *C-x* means *<control-x>*, *M-x* means *<alt-x>* and
 *S-<carriage-return>, Insert*
 	Print the filter text to standard output and exit.
 
-*C-l, <cursor-left>*
+*C-b, C-l, <cursor-left>*
 	Move cursor left.
 
 *C-f, <cursor-right>*


### PR DESCRIPTION
This brings the keybinds more in line with readline/emacs-style bindings. C-l to
go left is preserved for backwards compatibility. Notably, the curses backend
already had C-b to go left, but did not have C-l; it has not been changed.
