### PR TITLE
Fix mouse press being ignored on x11

### DIFF
--- a/lib/renderers/x11/window.c
+++ b/lib/renderers/x11/window.c
@@ -281,7 +281,7 @@ bm_x11_window_create(struct window *window, Display *display)
 
     XSetWindowAttributes wa = {
         .override_redirect = True,
-        .event_mask = ExposureMask | KeyPressMask | VisibilityChangeMask
+        .event_mask = ExposureMask | KeyPressMask | VisibilityChangeMask | ButtonPressMask
     };
 
     XVisualInfo vinfo;


### PR DESCRIPTION
Simple fix. Haven't tested, but this is included in dmenu and it respects mouse clicks.