### PR TITLE
Fix use after free in `wayland.c`

### DIFF
--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -547,8 +547,10 @@ recreate_windows(const struct bm_menu *menu, struct wayland *wayland)
         wl_output = output->output;
 
     if (!bm_wl_window_create(window, wayland->display, wayland->shm,
-                             wl_output, wayland->layer_shell, surface))
+                             wl_output, wayland->layer_shell, surface)) {
         free(window);
+        goto fail;
+    }
 
     window->notify.render = bm_cairo_paint;
     window->render_pending = true;


### PR DESCRIPTION
Pretty much the title. Not sure if you also want to just free in `fail` to begin with as it is only called after `window` is allocated. Execution is ultimately aborted so maybe just a simple `goto fail` instead of bothering to free.