### PR TITLE
wayland: bind to zwlr_layer_shell_v1 version 3

### DIFF
--- a/lib/renderers/wayland/registry.c
+++ b/lib/renderers/wayland/registry.c
@@ -582,7 +582,7 @@ registry_handle_global(void *data, struct wl_registry *registry, uint32_t id, co
     if (strcmp(interface, "wl_compositor") == 0) {
         wayland->compositor = wl_registry_bind(registry, id, &wl_compositor_interface, 4);
     } else if (strcmp(interface, zwlr_layer_shell_v1_interface.name) == 0) {
-        wayland->layer_shell = wl_registry_bind(registry, id, &zwlr_layer_shell_v1_interface, 2);
+        wayland->layer_shell = wl_registry_bind(registry, id, &zwlr_layer_shell_v1_interface, 3);
     } else if (strcmp(interface, "wl_seat") == 0) {
         wayland->seat = wl_registry_bind(registry, id, &wl_seat_interface, 7);
         wl_seat_add_listener(wayland->seat, &seat_listener, &wayland->input);


### PR DESCRIPTION
zwlr_layer_shell_v1_destroy is not available in version 2 of the interface.

I tried to fix this in https://github.com/Cloudef/bemenu/pull/249 but mistakenly thought that the request was added in version 2.