### PR TITLE
Correctness fixes (memory leaks, compiler warning, out-of-bounds read)

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -363,7 +363,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
             {
                 char *ptr;
                 client->lines = strtol(optarg, &ptr, 10);
-                client->lines_mode = (!strcmp(ptr + 1, "up") ? BM_LINES_UP : BM_LINES_DOWN);
+                client->lines_mode = (*ptr && !strcmp(ptr + 1, "up") ? BM_LINES_UP : BM_LINES_DOWN);
                 break;
             }
             case 'c':

--- a/lib/list.c
+++ b/lib/list.c
@@ -64,7 +64,7 @@ list_set_items(struct list *list, const void *items, uint32_t nmemb, list_free_f
     }
 
     void *new_items;
-    if (!(new_items = calloc(sizeof(void*), nmemb)))
+    if (!(new_items = calloc(nmemb, sizeof(void*))))
         return false;
 
     memcpy(new_items, items, sizeof(void*) * nmemb);

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -767,7 +767,7 @@ bm_menu_set_selected_items(struct bm_menu *menu, struct bm_item **items, uint32_
     assert(menu);
 
     struct bm_item **new_items;
-    if (!(new_items = calloc(sizeof(struct bm_item*), nmemb)))
+    if (!(new_items = calloc(nmemb, sizeof(struct bm_item*))))
         return 0;
 
     memcpy(new_items, items, sizeof(struct bm_item*) * nmemb);

--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -85,6 +85,8 @@ bm_cairo_destroy(struct cairo *cairo)
 {
     if (cairo->cr)
         cairo_destroy(cairo->cr);
+    if (cairo->pango)
+        g_object_unref(cairo->pango);
     if (cairo->surface)
         cairo_surface_destroy(cairo->surface);
 }

--- a/lib/renderers/wayland/registry.c
+++ b/lib/renderers/wayland/registry.c
@@ -631,8 +631,25 @@ bm_wl_registry_destroy(struct wayland *wayland)
 {
     assert(wayland);
 
+    if (wayland->viewporter)
+        wp_viewporter_destroy(wayland->viewporter);
+
+    if (wayland->wfs_mgr)
+        wp_fractional_scale_manager_v1_destroy(wayland->wfs_mgr);
+
+    struct output *output, *output_tmp;
+    wl_list_for_each_safe(output, output_tmp, &wayland->outputs, link) {
+        wl_list_remove(&output->link);
+        wl_output_destroy(output->output);
+        free(output->name);
+        free(output);
+    }
+
     if (wayland->shm)
         wl_shm_destroy(wayland->shm);
+
+    if (wayland->seat)
+        wl_seat_destroy(wayland->seat);
 
     if (wayland->layer_shell)
         zwlr_layer_shell_v1_destroy(wayland->layer_shell);

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -465,10 +465,11 @@ wl_surface_leave(void *data, struct wl_surface *wl_surface,
     (void)wl_surface;
     struct window *window = data;
 
-    struct surf_output *surf_output;
-    wl_list_for_each(surf_output, &window->surf_outputs, link) {
+    struct surf_output *surf_output, *surf_output_tmp;
+    wl_list_for_each_safe(surf_output, surf_output_tmp, &window->surf_outputs, link) {
         if (surf_output->output->output == wl_output) {
             wl_list_remove(&surf_output->link);
+            free(surf_output);
             break;
         }
     }
@@ -484,11 +485,12 @@ static const struct wl_surface_listener surface_listener = {
 static void
 destroy_windows(struct wayland *wayland)
 {
-    struct window *window;
-    wl_list_for_each(window, &wayland->windows, link) {
+    struct window *window, *window_tmp;
+    wl_list_for_each_safe(window, window_tmp, &wayland->windows, link) {
+        wl_list_remove(&window->link);
         bm_wl_window_destroy(window);
+        free(window);
     }
-    wl_list_init(&wayland->windows);
 }
 
 void

--- a/lib/renderers/wayland/wayland.h
+++ b/lib/renderers/wayland/wayland.h
@@ -81,7 +81,6 @@ struct touch_event {
 struct input {
     int *repeat_fd;
 
-    struct wl_seat *seat;
     struct wl_keyboard *keyboard;
     struct wl_pointer *pointer;
     struct wl_touch *touch;

--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -297,6 +297,12 @@ bm_wl_window_destroy(struct window *window)
 
     if (window->surface)
         wl_surface_destroy(window->surface);
+
+    struct surf_output *surf_output, *surf_output_tmp;
+    wl_list_for_each_safe(surf_output, surf_output_tmp, &window->surf_outputs, link) {
+        wl_list_remove(&surf_output->link);
+        free(surf_output);
+    }
 }
 
 static void


### PR DESCRIPTION
This PR is a small pack with fixes for 4 memory leaks found using Valgrind, a harmless GCC 14 compiler warning, and an out-of-bounds read when parsing the --list command line argument. None of the changes should affect user-visible behaviour.

The "wayland: Fix seat resource release logic" commit is a bit more interesting because it not only leaks memory, but it can also cause event handlers (e.g. `keyboard_handle_key`) to be called multiple times. I think this is harmless in the current bemenu implementation, but it caused issues on a branch I am working on.
