### PR TITLE
Fix: In vim mode dw causes deadlock #414

### DIFF
--- a/lib/vim.c
+++ b/lib/vim.c
@@ -148,9 +148,8 @@ static void delete_char_back(struct bm_menu *menu){
 static void delete_word(struct bm_menu *menu){
     if(!menu->filter) return;
 
-    size_t filter_length = strlen(menu->filter);
-    while (menu->cursor < filter_length && !isspace(menu->filter[menu->cursor])) delete_char(menu);
-    while (menu->cursor < filter_length && isspace(menu->filter[menu->cursor])) delete_char(menu);
+    while (menu->cursor < strlen(menu->filter) && !isspace(menu->filter[menu->cursor])) delete_char(menu);
+    while (menu->cursor < strlen(menu->filter) && isspace(menu->filter[menu->cursor])) delete_char(menu);
 }
 
 static void delete_word_back(struct bm_menu *menu){


### PR DESCRIPTION
issue #414 

the filter_length should be updated on each iteration. deleting the character causes the filter value to change, but it compares against the old size.

 