### PR TITLE
Account for vertical offset of monitor in x11 #426

### DIFF
--- a/lib/renderers/x11/window.c
+++ b/lib/renderers/x11/window.c
@@ -117,7 +117,7 @@ bm_x11_window_render(struct window *window, struct bm_menu *menu)
                 win_y = window->max_height - window->height;
         }
 
-        XMoveResizeWindow(window->display, window->drawable, window->x, win_y + window->y_offset, window->width, window->height);
+        XMoveResizeWindow(window->display, window->drawable, window->x, window->y + win_y + window->y_offset, window->width, window->height);
     }
 
     if (buffer->created) {


### PR DESCRIPTION
Issue #426 

I can confirm that default, `--center` and `--bottom` work with these changes on my monitor which has a vertical offset of 420px.  I also tested it with the vertical offset removed and it still worked.  I also tested it on my vertical monitor (offset 1920x0) and it still worked.  I don't know if any other edge cases need testing.