### PR TITLE
Feat: fuzzy matching flag -z

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -172,6 +172,7 @@ usage(FILE *out, const char *name)
           " -h, --help            display this help and exit.\n"
           " -v, --version         display version.\n"
           " -i, --ignorecase      match items case insensitively.\n"
+          " -z, --fuzzy           enable fuzzy matching.\n"
           " -F, --filter          filter entries for a given string before showing the menu.\n"
           " -w, --wrap            wraps cursor selection.\n"
           " -l, --list            list items vertically down or up with the given number of lines(number of lines down/up). (down (default), up)\n"
@@ -272,6 +273,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
         { "version",      no_argument,       0, 'v' },
 
         { "ignorecase",   no_argument,       0, 'i' },
+        { "fuzzy",        no_argument,       0, 'z' },
         { "filter",       required_argument, 0, 'F' },
         { "wrap",         no_argument,       0, 'w' },
         { "list",         required_argument, 0, 'l' },
@@ -340,7 +342,7 @@ do_getopt(struct client *client, int *argc, char **argv[])
     for (optind = 0;;) {
         int32_t opt;
 
-        if ((opt = getopt_long(*argc, *argv, "hviwcl:I:p:P:I:x:bfF:m:H:M:W:B:R:nsCTK", opts, NULL)) < 0)
+        if ((opt = getopt_long(*argc, *argv, "hvizwcl:I:p:P:I:x:bfF:m:H:M:W:B:R:nsCTK", opts, NULL)) < 0)
             break;
         
         switch (opt) {
@@ -352,6 +354,9 @@ do_getopt(struct client *client, int *argc, char **argv[])
                 break;
             case 'i':
                 client->filter_mode = BM_FILTER_MODE_DMENU_CASE_INSENSITIVE;
+                break;
+            case 'z':
+                client->fuzzy = true;
                 break;
             case 'F':
                 client->initial_filter = optarg;
@@ -594,6 +599,8 @@ menu_with_options(struct client *client)
     bm_menu_set_border_size(menu, client->border_size);
     bm_menu_set_border_radius(menu, client->border_radius);
     bm_menu_set_key_binding(menu, client->key_binding);
+    bm_menu_set_fuzzy_mode(menu, client->fuzzy);
+
 
     if (client->center) {
         bm_menu_set_align(menu, BM_ALIGN_CENTER);

--- a/client/common/common.h
+++ b/client/common/common.h
@@ -46,6 +46,7 @@ struct client {
     enum bm_password_mode password;
     enum bm_key_binding key_binding;
     char *monitor_name;
+    bool fuzzy;
 };
 
 char* cstrcopy(const char *str, size_t size);

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -934,6 +934,14 @@ BM_PUBLIC enum bm_password_mode bm_menu_get_password(struct bm_menu *menu);
  */
 BM_PUBLIC void bm_menu_set_key_binding(struct bm_menu *menu, enum bm_key_binding);
 
+/**
+ * Specify whether fuzzy matching should be used.
+ *
+ * @param menu bm_menu instance to set the fuzzy mode on.
+ * @param fuzzy true to enable fuzzy matching.
+ */
+BM_PUBLIC void bm_menu_set_fuzzy_mode(struct bm_menu *menu, bool fuzzy);
+
 
 /**  @} Properties */
 

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -457,6 +457,11 @@ struct bm_menu {
      */
     char vim_mode;
     uint32_t vim_last_key;
+
+    /**
+     * Should fuzzy matching be used?
+     */
+    bool fuzzy;
 };
 
 /* library.c */

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -779,6 +779,11 @@ bm_menu_set_key_binding(struct bm_menu *menu, enum bm_key_binding key_binding){
     menu->key_binding = key_binding;
 }
 
+void
+bm_menu_set_fuzzy_mode(struct bm_menu *menu, bool fuzzy){
+    menu->fuzzy = fuzzy;
+}
+
 struct bm_item**
 bm_menu_get_selected_items(const struct bm_menu *menu, uint32_t *out_nmemb)
 {

--- a/man/bemenu.1.scd.in
+++ b/man/bemenu.1.scd.in
@@ -45,6 +45,9 @@ list of executables under PATH and the selected items are executed.
 *-i, --ignorecase*
 	Filter items case-insensitively.
 
+*-z, --fuzzy*
+	Filter items fuzzily.
+
 *-K, --no-keyboard*
 	Disable all keyboard events.
 


### PR DESCRIPTION
Adds the option to use fuzzy matching when filtering menu items, along with the necessary flag and usage info.

Port of / strongly inspired by: https://tools.suckless.org/dmenu/patches/fuzzymatch/dmenu-fuzzymatch-4.6.diff

Would close https://github.com/Cloudef/bemenu/issues/367