### PR TITLE
Fix: Working --center flag on kwin and smithay-based compositors

### DIFF
--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -226,7 +226,7 @@ get_align_anchor(enum bm_align align)
     if(align == BM_ALIGN_TOP) {
         anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
     } else if(align == BM_ALIGN_CENTER) {
-        anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
+        anchor = 0;
     } else {
         anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
     }


### PR DESCRIPTION
Partially fixes #422.

Setting the centered anchor to 0 fixes the -c/--center flag for smithay-based compositors, and doesn't appear to break it for others (e.g., Hyprland).

The -W/--width-factor flag is still broken. This commit fixes -W when bemenu is centered, but not on other anchor points.

Tested on niri (Smithay-based), and Hyprland.