### PR TITLE
Overhaul Wayland initial gathering workflow

### DIFF
--- a/client/common/common.c
+++ b/client/common/common.c
@@ -561,7 +561,7 @@ struct bm_menu*
 menu_with_options(struct client *client)
 {
     struct bm_menu *menu;
-    if (!(menu = bm_menu_new(NULL)))
+    if (!(menu = bm_menu_new(NULL, !client->no_overlap)))
         return NULL;
 
     if (client->vim_init_mode_normal) {

--- a/lib/bemenu.h
+++ b/lib/bemenu.h
@@ -401,7 +401,7 @@ enum bm_key_binding {
  * @param renderer Name of renderer to be used for this instance, pass **NULL** for auto-detection.
  * @return bm_menu for new menu instance, **NULL** if creation failed.
  */
-BM_PUBLIC struct bm_menu* bm_menu_new(const char *renderer);
+BM_PUBLIC struct bm_menu* bm_menu_new(const char *renderer, bool overlap);
 
 /**
  * Release bm_menu instance.

--- a/lib/menu.c
+++ b/lib/menu.c
@@ -47,7 +47,7 @@ static struct bm_item** (*filter_func[BM_FILTER_MODE_LAST])(struct bm_menu *menu
 };
 
 struct bm_menu*
-bm_menu_new(const char *renderer)
+bm_menu_new(const char *renderer, bool overlap)
 {
     struct bm_menu *menu;
     if (!(menu = calloc(1, sizeof(struct bm_menu))))
@@ -58,6 +58,7 @@ bm_menu_new(const char *renderer)
     menu->key_binding = BM_KEY_BINDING_DEFAULT;
     menu->vim_mode = 'i';
     menu->vim_last_key = 0;
+    menu->overlap = overlap;
 
     uint32_t count;
     const struct bm_renderer **renderers = bm_get_renderers(&count);

--- a/lib/renderers/wayland/registry.c
+++ b/lib/renderers/wayland/registry.c
@@ -577,7 +577,7 @@ registry_handle_global(void *data, struct wl_registry *registry, uint32_t id, co
     struct wayland *wayland = data;
 
     if (strcmp(interface, "wl_compositor") == 0) {
-        wayland->compositor = wl_registry_bind(registry, id, &wl_compositor_interface, 4);
+        wayland->compositor = wl_registry_bind(registry, id, &wl_compositor_interface, 6);
     } else if (strcmp(interface, zwlr_layer_shell_v1_interface.name) == 0) {
         wayland->layer_shell = wl_registry_bind(registry, id, &zwlr_layer_shell_v1_interface, 3);
     } else if (strcmp(interface, "wl_seat") == 0) {

--- a/lib/renderers/wayland/wayland.c
+++ b/lib/renderers/wayland/wayland.c
@@ -438,49 +438,141 @@ set_overlap(const struct bm_menu *menu, bool overlap)
 }
 
 void
-wl_surface_enter(void *data, struct wl_surface *wl_surface,
+gather_surface_enter(void *data, struct wl_surface *wl_surface,
                  struct wl_output *wl_output)
 {
-    (void)wl_surface;
-    struct window *window = data;
-    struct wayland *wayland = window->wayland;
-
-    struct output *output;
-    wl_list_for_each(output, &wayland->outputs, link) {
-        if (output->output == wl_output) {
-            struct surf_output *surf_output = calloc(1, sizeof(struct surf_output));
-            surf_output->output = output;
-            wl_list_insert(&window->surf_outputs, &surf_output->link);
-            break;
-        }
-    }
-
-    window_update_output(window);
+    (void)data, (void)wl_surface, (void)wl_output;
 }
 
 void
-wl_surface_leave(void *data, struct wl_surface *wl_surface,
+gather_surface_leave(void *data, struct wl_surface *wl_surface,
                  struct wl_output *wl_output)
+{
+    (void)data, (void)wl_surface, (void)wl_output;
+}
+
+void
+gather_preferred_buffer_scale(void *data, struct wl_surface *wl_surface,
+                          int scale)
 {
     (void)wl_surface;
     struct window *window = data;
 
-    struct surf_output *surf_output, *surf_output_tmp;
-    wl_list_for_each_safe(surf_output, surf_output_tmp, &window->surf_outputs, link) {
-        if (surf_output->output->output == wl_output) {
-            wl_list_remove(&surf_output->link);
-            free(surf_output);
-            break;
-        }
-    }
-
-    window_update_output(window);
+    window->pref_scale = scale;
 }
 
-static const struct wl_surface_listener surface_listener = {
-    .enter = wl_surface_enter,
-    .leave = wl_surface_leave,
+void
+gather_preferred_buffer_transform(void *data, struct wl_surface *wl_surface,
+                              uint32_t transform)
+{
+    (void)data, (void)wl_surface, (void)transform;
+}
+
+static const struct wl_surface_listener gather_surface_listener = {
+    .enter = gather_surface_enter,
+    .leave = gather_surface_leave,
+    .preferred_buffer_scale = gather_preferred_buffer_scale,
+    .preferred_buffer_transform = gather_preferred_buffer_transform,
 };
+
+static void
+gather_fractional_preferred_scale(
+    void *data, struct wp_fractional_scale_v1 *wp_fractional_scale_v1,
+    uint32_t scale)
+{
+    (void)wp_fractional_scale_v1;
+    struct window *window = data;
+
+    window->pref_fractional_scale = (double)scale / 120;
+}
+
+static const struct wp_fractional_scale_v1_listener gather_fractional_listener = {
+    .preferred_scale = gather_fractional_preferred_scale,
+};
+
+void
+gather_shell_configure(void *data, struct zwlr_layer_surface_v1 *surface,
+                   uint32_t serial, uint32_t w, uint32_t h)
+{
+    struct window *window = data;
+    window->max_width = w;
+    window->max_height = h;
+    zwlr_layer_surface_v1_ack_configure(surface, serial);
+}
+
+void
+gather_shell_closed(void *data, struct zwlr_layer_surface_v1 *surface)
+{
+    (void)data, (void)surface;
+}
+
+static const struct zwlr_layer_surface_v1_listener gather_shell_listener = {
+    .configure = gather_shell_configure,
+    .closed = gather_shell_closed,
+};
+
+bool
+gather_context(struct window *window, struct output *output, struct wayland *wayland, bool overlap)
+{
+    struct wl_surface *surface = NULL;
+    if (!(surface = wl_compositor_create_surface(wayland->compositor)))
+        return false;
+
+    wl_surface_add_listener(surface, &gather_surface_listener, window);
+
+    if (wayland->fractional_scaling) {
+        assert(wayland->wfs_mgr && wayland->viewporter);
+
+        struct wp_fractional_scale_v1 *wfs_surf = wp_fractional_scale_manager_v1_get_fractional_scale(wayland->wfs_mgr, surface);
+        wp_fractional_scale_v1_add_listener(
+            wfs_surf, &gather_fractional_listener, window);
+    }
+
+    struct wl_output *wl_output = NULL;
+    if (output)
+        wl_output = output->output;
+
+    struct zwlr_layer_surface_v1 *layer_surface = NULL;
+    enum zwlr_layer_shell_v1_layer layer = ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY;
+    if (!(layer_surface = zwlr_layer_shell_v1_get_layer_surface(wayland->layer_shell, surface,
+                                                                wl_output, layer, "menu")))
+        return false;
+
+    zwlr_layer_surface_v1_set_anchor(layer_surface,
+                                     ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
+                                     ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
+                                     ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT |
+                                     ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
+    zwlr_layer_surface_v1_set_exclusive_zone(layer_surface, overlap ? -1 : 0);
+
+    window->scale = 0;
+    window->pref_scale = 0;
+    window->pref_fractional_scale = 0;
+    window->max_width = 0;
+    window->max_height = 0;
+
+    zwlr_layer_surface_v1_add_listener(layer_surface, &gather_shell_listener, window);
+    wl_surface_commit(surface);
+    wl_display_roundtrip(wayland->display);
+
+    zwlr_layer_surface_v1_destroy(layer_surface);
+    wl_surface_destroy(surface);
+    wl_display_roundtrip(wayland->display);
+
+    if (0 != window->pref_fractional_scale) {
+        window->scale = window->pref_fractional_scale;
+    } else {
+        window->scale = window->pref_scale;
+    }
+
+    if (!(window->scale && window->max_width && window->max_height))
+        return false;
+
+    window->max_width *= window->scale;
+    window->max_height *= window->scale;
+
+    return true;
+}
 
 static void
 destroy_windows(struct wayland *wayland)
@@ -494,58 +586,28 @@ destroy_windows(struct wayland *wayland)
 }
 
 void
-window_update_output(struct window *window)
-{
-    int32_t max_scale = 1;
-    uint32_t min_max_height = 0;
-
-    struct surf_output *surf_output;
-    wl_list_for_each(surf_output, &window->surf_outputs, link) {
-        if (surf_output->output->scale > max_scale) {
-            max_scale = surf_output->output->scale;
-        }
-        if (min_max_height == 0 || surf_output->output->height < min_max_height) {
-            min_max_height = surf_output->output->height;
-        };
-    }
-
-    if (min_max_height != window->max_height) {
-        window->max_height = min_max_height;
-    }
-
-    if (max_scale != window->scale) {
-        window->scale = max_scale;
-    }
-}
-
-void
 recreate_windows(const struct bm_menu *menu, struct wayland *wayland)
 {
     destroy_windows(wayland);
 
     struct window *window = calloc(1, sizeof(struct window));
-    wl_list_init(&window->surf_outputs);
     window->wayland = wayland;
     window->align = menu->align;
     window->hmargin_size = menu->hmargin_size;
     window->width_factor = menu->width_factor;
-
-    // TODO: this should not be necessary, but Sway 1.8.1 does not trigger event
-    // surface.enter before we actually need to render the first frame.
-    window->scale = 1;
-    window->max_height = 640;
-
-    struct wl_surface *surface = NULL;
-    if (!(surface = wl_compositor_create_surface(wayland->compositor)))
-        goto fail;
-
-    wl_surface_add_listener(surface, &surface_listener, window);
 
     struct output *output = NULL;
     if (wayland->selected_output) {
         fprintf(stderr, "selected output\n");
         output = wayland->selected_output;
     };
+
+    if (!gather_context(window, output, wayland, menu->overlap))
+        goto fail;
+
+    struct wl_surface *surface = NULL;
+    if (!(surface = wl_compositor_create_surface(wayland->compositor)))
+        goto fail;
 
     struct wl_output *wl_output = NULL;
     if (output)

--- a/lib/renderers/wayland/wayland.h
+++ b/lib/renderers/wayland/wayland.h
@@ -116,17 +116,16 @@ struct buffer {
 
 struct window {
     struct wayland *wayland;
-    struct wl_list surf_outputs;
     struct wl_surface *surface;
     struct wl_callback *frame_cb;
     struct zwlr_layer_surface_v1 *layer_surface;
     struct wp_viewport *viewport_surface;
     struct wl_shm *shm;
     struct buffer buffers[2];
-    uint32_t width, height, max_height;
+    uint32_t width, height, max_height, max_width;
     uint32_t hmargin_size;
     float width_factor;
-    double scale;
+    double scale, pref_fractional_scale, pref_scale;
     uint32_t displayed;
     struct wl_list link;
     enum bm_align align;

--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -303,12 +303,6 @@ bm_wl_window_destroy(struct window *window)
 
     if (window->surface)
         wl_surface_destroy(window->surface);
-
-    struct surf_output *surf_output, *surf_output_tmp;
-    wl_list_for_each_safe(surf_output, surf_output_tmp, &window->surf_outputs, link) {
-        wl_list_remove(&surf_output->link);
-        free(surf_output);
-    }
 }
 
 static void
@@ -342,21 +336,6 @@ get_window_width(struct window *window)
 
     return width;
 }
-
-static void
-fractional_scale_preferred_scale(
-    void *data, struct wp_fractional_scale_v1 *wp_fractional_scale_v1,
-    uint32_t scale)
-{
-    (void)wp_fractional_scale_v1;
-    struct window *window = data;
-
-    window->scale = (double)scale / 120;
-}
-
-static const struct wp_fractional_scale_v1_listener fractional_scale_listener = {
-    .preferred_scale = fractional_scale_preferred_scale,
-};
 
 static const struct zwlr_layer_surface_v1_listener layer_surface_listener = {
     .configure = layer_surface_configure,
@@ -433,9 +412,6 @@ bm_wl_window_create(struct window *window, struct wl_display *display, struct wl
     if (wayland->fractional_scaling) {
         assert(wayland->wfs_mgr && wayland->viewporter);
 
-        struct wp_fractional_scale_v1 *wfs_surf = wp_fractional_scale_manager_v1_get_fractional_scale(wayland->wfs_mgr, surface);
-        wp_fractional_scale_v1_add_listener(
-            wfs_surf, &fractional_scale_listener, window);
         window->viewport_surface = wp_viewporter_get_viewport(wayland->viewporter, surface);
     }
 

--- a/man/bemenu.1.scd.in
+++ b/man/bemenu.1.scd.in
@@ -168,7 +168,7 @@ These options are only available on backends specified in the parentheses:
 	should appear on all monitors.
 
 *-n, --no-overlap* (Wayland)
-	Set the *bemenu* window to be on top of any other panels.
+	Make the *bemenu* window to not overlap any other panels.
 
 *-M, --margin* <_margin_> (Wayland, X11)
 	Specify the _margin_ (empty space) in pixels to leave between menu and


### PR DESCRIPTION
Replace: https://github.com/Cloudef/bemenu/pull/431

# wayland: overhaul the context gathering workflow

The current init workflow has multiple limitations. Asking for the Wayland folks brings me to implement this alternative approach:

https://gitlab.freedesktop.org/wayland/wayland/-/issues/576

Previously we was using the global advertised wl_outputs. We then wait for the wl_surface.enter event to know which output we are displayed on. (We also use this to determine the surface scale value, not the fractional value). This is wrong, and slowly deprecated by the protocol. Other layer shell surface might limit the available geometry our menus can use. This also means we receive this information very late in the workflow, after commiting the first layer_shell with a random max_height.

The correct way is to first create a layer shell, anchored to the four corners. Its configure event then advertises us of the available geometry.

This bump the wl_compositor version to 6, to receive the wl_surface.preferred_buffer_scale directly, instead of computing it ourselves using the surf_outputs.

# wayland: fix --no-overlap meaning and behavior

As I understand "no overlap", it means "do not overlap". This correspond to this call from the Wayland backend:

zwlr_layer_surface_v1_set_exclusive_zone(..., overlap ? -1 : 0);

The spec says:

> If set to zero, the surface indicates that it would like to be moved to avoid occluding surfaces with a positive exclusive zone. If set to -1, the surface indicates that it would not like to be moved to accommodate for other surfaces, and the compositor should extend it all the way to the edges it is anchored to.

So "0" is "do not overlap", and "-1" is "overlap", okay.

The problem is that the overlap boolean comes from !client->no_overlap. Meaning that -n => true => !true => false so -n gives 0 "do not overlap"

I think the code is correct, but the description of the argument is miss-leading.

Also, we initiate the menu->overlap sooner, because the renderer need this to gather the maximum available geometry correctly. I'm not sure if this the best way to to so.
