### PR TITLE
fix: prevent background overlap in vertical mode

### DIFF
--- a/lib/renderers/cairo_renderer.h
+++ b/lib/renderers/cairo_renderer.h
@@ -472,7 +472,7 @@ bm_cairo_paint(struct cairo *cairo, uint32_t width, uint32_t max_height, struct 
             bm_cairo_color_from_menu_color(menu, BM_COLOR_ITEM_BG, &paint.bg);
             const uint32_t sheight = out_result->height - titleh;
             cairo_set_source_rgba(cairo->cr, paint.bg.r, paint.bg.b, paint.bg.g, paint.bg.a);
-            cairo_rectangle(cairo->cr, scrollbar_w + border_size, titleh + border_size, spacing_x - scrollbar_w, sheight);
+            cairo_rectangle(cairo->cr, scrollbar_w + border_size, titleh + border_size, spacing_x - scrollbar_w - 4, sheight);
             cairo_fill(cairo->cr);
         }
 


### PR DESCRIPTION
Fixes visual artifacts when using transparent `--nb` colors.
The spacing background rectangle was extending 4px beyond, causing overlap with item area.

Example command:
```sh
bemenu-run -c -W 0.2 -l 5 --nb "#00ff0055"
```

Before:
<img width="234" height="125" alt="2026-01-16-213754_hyprshot" src="https://github.com/user-attachments/assets/22d6352a-a579-4e86-88b0-bd2d05e7dd0f" />
After:
<img width="231" height="123" alt="2026-01-16-213647_hyprshot" src="https://github.com/user-attachments/assets/8c1e9e39-9f3c-4d7a-b05b-9dd6ee0a467f" />

