### PR TITLE
Fix width-factor for river >=0.3.13

### DIFF
--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -371,9 +371,10 @@ bm_wl_window_set_width(struct window *window, struct wl_display *display, uint32
 
     window->hmargin_size = margin;
     window->width_factor = factor;
+    window->width = get_window_width(window);
 
     zwlr_layer_surface_v1_set_anchor(window->layer_surface, window->align_anchor);
-    zwlr_layer_surface_v1_set_size(window->layer_surface, get_window_width(window), window->height);
+    zwlr_layer_surface_v1_set_size(window->layer_surface, window->width, window->height);
 
     wl_surface_commit(window->surface);
     wl_display_roundtrip(display);

--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -246,6 +246,21 @@ bm_wl_window_schedule_render(struct window *window)
     wl_surface_commit(window->surface);
 }
 
+
+static uint32_t
+get_window_width(struct window *window)
+{
+    uint32_t width = window->width * ((window->width_factor != 0) ? window->width_factor : 1);
+
+    if(width > window->width - 2 * window->hmargin_size)
+        width = window->width - 2 * window->hmargin_size;
+
+    if(width < WINDOW_MIN_WIDTH || 2 * window->hmargin_size > window->width)
+        width = WINDOW_MIN_WIDTH;
+
+    return width;
+}
+
 void
 bm_wl_window_render(struct window *window, struct wl_display *display, struct bm_menu *menu)
 {
@@ -269,7 +284,7 @@ bm_wl_window_render(struct window *window, struct wl_display *display, struct bm
             break;
 
         window->height = ceil(result.height / window->scale);
-        zwlr_layer_surface_v1_set_size(window->layer_surface, window->width, window->height);
+        zwlr_layer_surface_v1_set_size(window->layer_surface, get_window_width(window), window->height);
         destroy_buffer(buffer);
     }
 
@@ -327,20 +342,6 @@ layer_surface_closed(void *data, struct zwlr_layer_surface_v1 *layer_surface)
     zwlr_layer_surface_v1_destroy(layer_surface);
     wl_surface_destroy(window->surface);
     exit(1);
-}
-
-static uint32_t
-get_window_width(struct window *window)
-{
-    uint32_t width = window->width * ((window->width_factor != 0) ? window->width_factor : 1);
-
-    if(width > window->width - 2 * window->hmargin_size)
-        width = window->width - 2 * window->hmargin_size;
-
-    if(width < WINDOW_MIN_WIDTH || 2 * window->hmargin_size > window->width)
-        width = WINDOW_MIN_WIDTH;
-
-    return width;
 }
 
 static void

--- a/lib/renderers/wayland/window.c
+++ b/lib/renderers/wayland/window.c
@@ -246,21 +246,6 @@ bm_wl_window_schedule_render(struct window *window)
     wl_surface_commit(window->surface);
 }
 
-
-static uint32_t
-get_window_width(struct window *window)
-{
-    uint32_t width = window->width * ((window->width_factor != 0) ? window->width_factor : 1);
-
-    if(width > window->width - 2 * window->hmargin_size)
-        width = window->width - 2 * window->hmargin_size;
-
-    if(width < WINDOW_MIN_WIDTH || 2 * window->hmargin_size > window->width)
-        width = WINDOW_MIN_WIDTH;
-
-    return width;
-}
-
 void
 bm_wl_window_render(struct window *window, struct wl_display *display, struct bm_menu *menu)
 {
@@ -284,7 +269,7 @@ bm_wl_window_render(struct window *window, struct wl_display *display, struct bm
             break;
 
         window->height = ceil(result.height / window->scale);
-        zwlr_layer_surface_v1_set_size(window->layer_surface, get_window_width(window), window->height);
+        zwlr_layer_surface_v1_set_size(window->layer_surface, window->width, window->height);
         destroy_buffer(buffer);
     }
 
@@ -342,6 +327,20 @@ layer_surface_closed(void *data, struct zwlr_layer_surface_v1 *layer_surface)
     zwlr_layer_surface_v1_destroy(layer_surface);
     wl_surface_destroy(window->surface);
     exit(1);
+}
+
+static uint32_t
+get_window_width(struct window *window)
+{
+    uint32_t width = window->width * ((window->width_factor != 0) ? window->width_factor : 1);
+
+    if(width > window->width - 2 * window->hmargin_size)
+        width = window->width - 2 * window->hmargin_size;
+
+    if(width < WINDOW_MIN_WIDTH || 2 * window->hmargin_size > window->width)
+        width = WINDOW_MIN_WIDTH;
+
+    return width;
 }
 
 static void


### PR DESCRIPTION
Commit [df131f9a](https://codeberg.org/river/river-classic/commit/df131f9a9d454ca60fa58e85edda5bd1eff16956) to [river-classic](https://codeberg.org/river/river-classic), broke the `--width-factor -W` feature in bemenu, causing bemenu to always render with full width.  From my testing with similar menu applications and sway, it seems to be strictly a bemenu/river-classic incompatibility.  Based on issue #449, I'm inclined to believe that river simply exposed an existing bug in bemenu.

My PR should be considered a hotfix.   It doesn't actually fix #449 because I'm frankly ignorant what a correct wayland round trip would be.  I can say it doesn't break bemenu's width on sway.